### PR TITLE
[codex] simplify skill workflow definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,15 @@
 
 English | [中文](README.zh.md)
 
-An engineering control framework for automated AI coding. Its core assumption is that architecture, phase boundaries,
-entry/exit criteria, and implementation control plans are prepared first; after that, a controller agent can advance each
-phase automatically until the local branch reaches `ready-to-open-draft-PR`.
+An engineering control framework for automated AI coding. Its core assumption is that architecture, phase/work-unit
+boundaries, entry/exit criteria, and implementation control plans are prepared first; after that, agents can execute inside
+explicit gates with durable artifacts, review decisions, residual-risk tracking, and accepted checkpoints.
 
-This is not a loose collection of prompts. It is a workflow for putting AI coding inside an engineering loop: adjudicate
-design and plans, implement by slices, review code, fix findings, re-review, run aggregate deep review, track residual
-risks, and create local accepted commits. The controller stops for the user only when there is a blocking open question,
-unclear scope or ownership, validation failure, residual risk requiring human judgment, first entry into the draft PR gate,
-or external actions such as merge, approval, marking a PR ready for review, or public comments. After the user authorizes
-the draft PR gate, it automatically pushes, creates a draft PR, runs PR review, fixes findings, re-reviews, creates an
-accepted PR review commit, and pushes again until `draft-PR-pass`.
+This is not a loose collection of prompts. It is a workflow for putting AI coding inside an engineering loop: confirm goals
+and non-goals, plan, review, implement by slices, review code, fix findings, re-review, run aggregate deep review, track
+residual risks, create accepted commits, open a draft PR, run PR review, and continue until `draft-PR-pass`. Merge,
+approval, marking a PR ready for review, requesting reviewers, deleting branches, public comments, and external issue
+changes still require explicit user authorization.
 
 This repository contains local skills and supporting scripts for Codex / Claude Code, covering phase-driven development,
 gated feature development, plan review, deep code review, and multi-agent handoff.
@@ -26,24 +24,25 @@ This repository is the source of truth for the skills under `skills/`. Local Cod
 
 ## Included Skills
 
-| Skill | Use it when |
+| Skill | Responsibility |
 | --- | --- |
-| `gateflow` | You want to advance a complex feature, migration, refactor, schema change, public contract change, or architecture-sensitive task from plan to `ready-to-open-draft-PR`, then through the draft PR gate to `draft-PR-pass` after user authorization. |
-| `phaseflow` | You have a design source document and an implementation control document, and want to advance phase design, planning, implementation, review, risk tracking, and status updates. |
-| `planreview` | You want adversarial review of a plan, implementation plan, migration phase plan, feature slice plan, or Gateflow handoff plan. |
+| `gateflow` | Defines the gated workflow for one work unit: preflight, goal confirmation, fixed gate order, artifacts, residual risks, accepted commits, draft PR gate, and final closeout. It does not define project-level control documents or multi-agent routing. |
+| `phaseflow` | Project step controller. It reads `design_doc` and `control_doc`, identifies the current `phase = work unit`, performs preflight and goal confirmation with the user, reads Gateflow's `Gate Order`, dispatches concrete gates to Agents, adjudicates results, updates `control_doc`, and reconciles residual risks. |
+| `planreview` | You want adversarial review of a plan, implementation plan, migration phase plan, feature slice plan, or Gateflow plan. |
 | `deepreview` | You want strict code review of current workspace changes, a GitHub PR, or the whole repository. |
-| `init-agents` | You want a controller agent to communicate with other Codex / Claude Code agents through tmux panes. |
+| `init-agents` | Defines tmux communication only: Agent CLI type, `/skill` vs `$skill`, pane discovery, clear/session rules, `tmux-cli send/wait_idle/capture`, and send-safety rules. It does not assign roles. |
 
 ## Demo
 
 ```text
-Use $phaseflow. The design is in docs/host/design.md, and the control document is docs/host/implementation-control.md.
+按照 $phaseflow 推进，设计真源在 docs/host/design.md，总控文档是 docs/host/issues-implementation-control.md。
+严格遵循 AGENTS.md 的约束。
 ```
 
 Equivalent explicit argument form:
 
 ```text
-$phaseflow design_doc=docs/host/design.md control_doc=docs/host/implementation-control.md
+$phaseflow design_doc=docs/host/design.md control_doc=docs/host/issues-implementation-control.md
 ```
 
 ## Core Workflow
@@ -51,12 +50,13 @@ $phaseflow design_doc=docs/host/design.md control_doc=docs/host/implementation-c
 A typical flow is:
 
 1. Prepare the design source document, such as `docs/design.md` or `docs/host/design.md`.
-2. Prepare the implementation control document, such as `docs/implementation-control.md`, with phases, dependencies, entry criteria, exit criteria, validation requirements, and tracking items.
-3. Use `phaseflow` to read both documents, identify the current phase, refine design, and produce an implementation-ready plan.
-4. `phaseflow` then follows the `gateflow` gate order to automatically run plan review, plan fix, plan re-review, slice implementation, code review, code fix, code re-review, and accepted local commits.
-5. After all slices are complete, run aggregate deep review automatically; after fixes and re-review pass, update the control document and mark the phase complete.
-6. Stop at `ready-to-open-draft-PR` and report the branch, commits, artifacts, validation results, remaining risks, and draft PR readiness.
-7. After user authorization, `phaseflow` / `gateflow` automatically pushes, creates a draft PR, runs PR review, fixes accepted findings, re-reviews, creates an accepted PR review commit, and pushes again until `draft-PR-pass`.
+2. Prepare the implementation control document, such as `docs/implementation-control.md`, with phases/work units, status, validation requirements, artifacts, residual risks, and the next entry point.
+3. Use `phaseflow` to read both documents, identify the current `phase = work unit`, and perform preflight plus goal confirmation with the user.
+4. `phaseflow` reads Gateflow's `Gate Order` and dispatches concrete plan / implementation / review / fix gates to Agents.
+5. After each Agent return, `phaseflow` reads the artifact, adjudicates findings, updates `control_doc`, and advances to the next gate.
+6. After all slices are complete, run aggregate deep review; after fixes and re-review pass, record draft PR readiness and residual-risk ownership.
+7. The draft PR gate pushes, creates a draft PR, runs PR review, fixes accepted findings, re-reviews, creates an accepted PR review commit, and pushes again until `draft-PR-pass`.
+8. After each phase/work unit, `phaseflow` reconciles residual risks, closes resolved risks, marks the current phase complete, and writes the next entry point so the user can merge the PR and continue to the next phase.
 
 The point is not to let the agent invent architecture on the fly. The point is to let agents execute reliably inside
 explicit design boundaries and implementation plans, while leaving durable artifacts for every review conclusion, fix
@@ -370,57 +370,72 @@ glm_claude --title
 kimi_claude --title
 ```
 
-Expected pane titles:
+Expected pane titles and one possible assignment:
 
-| Function | Pane title | Typical role |
+| Function | Pane title | Example assignment |
 | --- | --- | --- |
-| `controller_codex --title` | `AgentController` | Controller |
-| `pro_codex --title` | `AgentCodex` | Implementation / fix |
+| `controller_codex --title` | `AgentController` | Phaseflow controller |
+| `pro_codex --title` | `AgentCodex` | Plan / implementation / fix |
 | `opus_claude --title` | `AgentOpus` | Review / re-review |
 | `ds_claude --title` | `AgentDS` | Review / re-review |
 | `mimo_claude --title` | `AgentMiMo` | Review / re-review |
 | `glm_claude --title` | `AgentGLM` | Review / re-review |
 | `kimi_claude --title` | `AgentKIMI` | Review / re-review |
 
+`init-agents` does not assign these roles. Put the desired assignment in the current user prompt.
+
 ## Usage
 
 ### Gateflow
 
-Use `gateflow` when you want the agent to run a gated controller workflow from plan to implementation review and local readiness.
+Use `gateflow` for one work unit: a feature, issue, bug fix, migration, refactor, schema/public contract change, or
+architecture-sensitive task. Gateflow defines the gates only: preflight, goal confirmation, plan, review, implementation
+slices, fixes, aggregate deep review, accepted commits, draft PR gate, and final closeout.
 
-Codex:
-
-```text
-Use $gateflow to develop <feature>.
-If the requirements are unclear, discuss first.
-```
-
-Claude Code:
+Standalone Gateflow example:
 
 ```text
-Use /gateflow to develop <feature>.
-If the requirements are unclear, discuss first.
+按照 $gateflow 开发 <work-unit>。
+可选设计依据：docs/host/design.md。
+先做 preflight 和 goal confirmation；用户确认目标、非目标和边界后，按 Gate Order 推进到 draft-PR-pass。
+严格遵循 AGENTS.md 的约束。
 ```
 
-`gateflow` is intended for complex work. It creates a plan, reviews the plan, runs implementation slices, reviews code, tracks residual risks, creates local accepted commits, and stops at `ready-to-open-draft-PR` for user authorization. After the user authorizes the draft PR gate, it automatically pushes, creates a draft PR, runs PR review, fixes findings, re-reviews, creates an accepted PR review commit, and pushes again until `draft-PR-pass`.
+Gateflow with `init-agents` example:
+
+```text
+按照 $gateflow 开发 <work-unit>。
+$init-agents 路由 Agents，AgentCodex 负责 plan / implement / fix，AgentMiMo / AgentDS 负责两路同时 review / re-review。
+每次发送前重新 discovery pane，clear 新任务 session，避免裸 #数字。
+严格遵循 AGENTS.md 的约束。
+```
 
 ### Phaseflow
 
-Use `phaseflow` when a project has a design source document and an implementation control document.
+Use `phaseflow` when a project has a design source document and an implementation control document. Phaseflow is the
+project step controller: it reads the current `phase = work unit`, performs preflight and goal confirmation with the user,
+reads Gateflow's `Gate Order`, dispatches concrete gates to Agents, adjudicates results, updates `control_doc`, and
+reconciles residual risks.
 
-Codex:
-
-```text
-Use $phaseflow with design_doc=<path/to/design.md> and control_doc=<path/to/control.md> to continue the next phase.
-```
-
-Claude Code:
+Standalone Phaseflow example:
 
 ```text
-Use /phaseflow with design_doc=<path/to/design.md> and control_doc=<path/to/control.md> to continue the next phase.
+按照 $phaseflow 推进，设计真源在 docs/host/design.md，总控文档是 docs/host/issues-implementation-control.md。
+先读取 control_doc 识别当前 phase/work unit，再读取 design_doc。
+总控 Agent 先完成 preflight 和 goal confirmation；用户确认后，按 Gateflow 的 Gate Order 逐 gate 派发 Agent 完成具体任务。
+每个 gate 返回后更新 control_doc、记录 artifact / finding 裁决 / residual risk。
+严格遵循 AGENTS.md 的约束。
 ```
 
-`phaseflow` follows `gateflow`, but adds control-document maintenance, phase status updates, risk tracking, and multi-agent review conventions.
+Phaseflow with `init-agents` example:
+
+```text
+按照 $phaseflow 推进，设计真源在 docs/host/design.md，总控文档是 docs/host/issues-implementation-control.md。
+$init-agents 路由 Agents，AgentMiMo / AgentDS 负责两路同时 review，AgentCodex 负责 plan / implement / fix。
+总控 Agent 先做 preflight 和 goal confirmation；确认后按 Gateflow 的 Gate Order 逐 gate 派发。
+每个 Agent 返回后，总控读取 artifact、裁决 finding、更新 control_doc、收集 residual risk、关闭已解决 risk。
+严格遵循 AGENTS.md 的约束。
+```
 
 ### Planreview
 
@@ -474,7 +489,9 @@ Expected output is a durable review artifact with evidence-based findings, statu
 
 ### Init Agents
 
-Use `init-agents` when the controller should not spawn built-in subagents, but should instead delegate work to already-running CLI agents through tmux panes.
+Use `init-agents` when work should be sent to already-running CLI agents through tmux panes. It only defines communication:
+CLI type, `/skill` vs `$skill`, pane discovery, clear/session rules, `tmux-cli send/wait_idle/capture`, and send safety.
+It does not assign roles.
 
 Codex:
 
@@ -488,7 +505,7 @@ Claude Code:
 Use /init-agents to initialize multi-agent communication conventions.
 ```
 
-`init-agents` assumes the controller only works with panes visible in the current tmux session/window via:
+`init-agents` works through:
 
 ```bash
 tmux-cli status
@@ -548,6 +565,7 @@ The sync script validates first, then copies every skill directory to existing l
 
 ## Notes
 
-- `gateflow` and `phaseflow` are controller workflows. Worker prompts should be role-scoped handoffs, not instructions to restart the full workflow.
+- `gateflow` defines the gates for one work unit.
+- `phaseflow` is the project step controller; concrete plan / implementation / review / fix work is delegated to Agents.
 - `planreview` and `deepreview` are review skills. They should produce durable artifacts, not just chat-only conclusions.
-- `init-agents` is optional unless you run multiple CLI agents through tmux.
+- `init-agents` is only needed when you route work to multiple CLI agents through tmux.

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,15 +2,14 @@
 
 [English](README.md) | 中文
 
-一套面向自动化 AI Coding 的工程控制框架。它的核心前提是：先把架构设计、phase 边界、进入 / 退出条件和
-implementation control plan 做扎实；之后由总控 Agent 按 phase 自动推进开发，直到本地达到 `ready-to-open-draft-PR`。
+一套面向自动化 AI Coding 的工程控制框架。它的核心前提是：先把架构设计、phase/work unit 边界、进入 / 退出条件和
+implementation control plan 做扎实；之后让 Agent 在明确 gate 内执行，留下 durable artifact、review decision、
+residual-risk tracking 和 accepted checkpoint。
 
-它不是一组零散 prompt，而是一套把 AI Coding 纳入工程闭环的工作流：先裁决设计和计划，再按 slice 实施，再做
-code review、fix、re-review、aggregate deepreview、residual risk tracking 和本地 accepted commits。只有遇到
-blocking open question、scope / ownership 不清、验证失败、残余风险需要人类裁决，或首次进入 draft PR gate、
-merge / approve / mark ready for review / 外部 comment 这类对外动作时，才停下来交给用户确认。用户授权 draft PR gate 后，
-它会自动 push、创建 draft PR、执行 PR review、fix、re-review、accepted PR review commit 和 follow-up push，直到
-`draft-PR-pass`。
+它不是一组零散 prompt，而是一套把 AI Coding 纳入工程闭环的工作流：确认目标和非目标，plan、review、按 slice 实施、
+code review、fix、re-review、aggregate deepreview、residual risk tracking、本地 accepted commits、创建 draft PR、执行
+PR review，并持续推进到 `draft-PR-pass`。merge、approve、mark ready for review、request reviewers、delete branch、
+对外 comment、创建/修改外部 issue 仍然需要用户额外授权。
 
 本仓库包含用于 Codex / Claude Code 的本地 skills 和配套脚本，覆盖 phase-driven development、gated feature
 development、plan review、deep code review 和多 Agent handoff。
@@ -24,24 +23,25 @@ development、plan review、deep code review 和多 Agent handoff。
 
 ## 包含的 Skills
 
-| Skill | 适用场景 |
+| Skill | 职责 |
 | --- | --- |
-| `gateflow` | 需要把复杂 feature、migration、refactor、schema change、public contract change 或 architecture-sensitive task 从 plan 自动推进到 `ready-to-open-draft-PR`，并在用户授权后推进 draft PR gate 到 `draft-PR-pass`。 |
-| `phaseflow` | 项目有设计真源文档和实施总控文档，需要按 phase 自动推进 design refinement、plan、implementation、review、risk tracking 和状态更新。 |
-| `planreview` | 需要 adversarial review 一个 plan、implementation plan、migration phase plan、feature slice plan 或 Gateflow handoff plan。 |
+| `gateflow` | 定义单个 work unit 的 gated workflow：preflight、goal confirmation、固定 gate order、artifacts、residual risks、accepted commits、draft PR gate 和 final closeout。它不定义项目级总控文档，也不定义多 Agent 路由。 |
+| `phaseflow` | 项目分步总控。读取 `design_doc` 和 `control_doc`，识别当前 `phase = work unit`，和用户完成 preflight / goal confirmation，读取 Gateflow 的 `Gate Order`，逐 gate 派发 Agent，裁决结果，更新 `control_doc`，并 reconcile residual risks。 |
+| `planreview` | 需要 adversarial review 一个 plan、implementation plan、migration phase plan、feature slice plan 或 Gateflow plan。 |
 | `deepreview` | 需要严格 review 当前 workspace 改动、GitHub PR 或整个仓库。 |
-| `init-agents` | 总控 Agent 需要通过 tmux pane 向其它 Codex / Claude Code Agent 派发任务。 |
+| `init-agents` | 只定义 tmux 通信：Agent CLI 类型、`/skill` vs `$skill`、pane discovery、clear/session 规则、`tmux-cli send/wait_idle/capture` 和发送安全规则。它不分配角色。 |
 
 ## 使用演示
 
 ```text
-使用 $phaseflow，设计在 docs/host/design.md，总控文档是 docs/host/implementation-control.md。
+按照 $phaseflow 推进，设计真源在 docs/host/design.md，总控文档是 docs/host/issues-implementation-control.md。
+严格遵循 AGENTS.md 的约束。
 ```
 
 等价的显式参数写法：
 
 ```text
-$phaseflow design_doc=docs/host/design.md control_doc=docs/host/implementation-control.md
+$phaseflow design_doc=docs/host/design.md control_doc=docs/host/issues-implementation-control.md
 ```
 
 ## 核心工作流
@@ -49,12 +49,13 @@ $phaseflow design_doc=docs/host/design.md control_doc=docs/host/implementation-c
 典型使用方式是：
 
 1. 先写好设计真源文档，例如 `docs/design.md` 或 `docs/host/design.md`。
-2. 再写好实施总控文档，例如 `docs/implementation-control.md`，记录 phase 列表、依赖、进入条件、退出条件、验证要求和后续追踪项。
-3. 使用 `phaseflow` 读取这两个文档，让总控 Agent 判断当前 phase、细化设计、生成可直接落地的 plan。
-4. `phaseflow` 随后按 `gateflow` 的 gate 顺序自动推进 plan review、plan fix、plan re-review、slice implementation、code review、code fix、code re-review，并生成本地 accepted commits。
-5. 所有 slices 完成后自动执行 aggregate deepreview；修复并复核通过后，更新总控文档，把 phase 标记为完成。
-6. 到达 `ready-to-open-draft-PR` 后停止，报告 branch、commits、artifacts、validation results、remaining risks 和 draft PR readiness。
-7. 用户授权后，`phaseflow` / `gateflow` 自动 push、创建 draft PR、执行 PR review；若有 accepted findings，则自动 fix、re-review、提交 accepted PR review commit 并再次 push，直到 `draft-PR-pass`。
+2. 再写好实施总控文档，例如 `docs/implementation-control.md`，记录 phases/work units、状态、验证要求、artifacts、residual risks 和 next entry point。
+3. 使用 `phaseflow` 读取这两个文档，识别当前 `phase = work unit`，并和用户完成 preflight 与 goal confirmation。
+4. `phaseflow` 读取 Gateflow 的 `Gate Order`，逐 gate 把 plan / implementation / review / fix 等具体任务派发给 Agent。
+5. 每个 Agent 返回后，`phaseflow` 读取 artifact、裁决 findings、更新 `control_doc`，再进入下一个 gate。
+6. 所有 slices 完成后执行 aggregate deepreview；修复并复核通过后，记录 draft PR readiness 和 residual-risk owner。
+7. draft PR gate 自动 push、创建 draft PR、执行 PR review；若有 accepted findings，则自动 fix、re-review、提交 accepted PR review commit 并再次 push，直到 `draft-PR-pass`。
+8. 每个 phase/work unit 完成后，`phaseflow` reconcile residual risks、关闭已解决风险、标记当前 phase 完成，并写入 next entry point，方便用户 merge PR 后继续下一个 phase。
 
 这个流程的目标不是让 Agent 自行发明架构，而是让 Agent 在已经明确的设计边界和总控计划内稳定执行，并把每一步的证据、
 review 结论、修复状态和 residual risks 留在可追踪 artifact 中。
@@ -367,57 +368,71 @@ glm_claude --title
 kimi_claude --title
 ```
 
-预期 pane title：
+预期 pane title 和一种可能的分工：
 
-| Function | Pane title | 常见角色 |
+| Function | Pane title | 示例分工 |
 | --- | --- | --- |
-| `controller_codex --title` | `AgentController` | 总控 |
-| `pro_codex --title` | `AgentCodex` | Implementation / fix |
+| `controller_codex --title` | `AgentController` | Phaseflow 总控 |
+| `pro_codex --title` | `AgentCodex` | Plan / implementation / fix |
 | `opus_claude --title` | `AgentOpus` | Review / re-review |
 | `ds_claude --title` | `AgentDS` | Review / re-review |
 | `mimo_claude --title` | `AgentMiMo` | Review / re-review |
 | `glm_claude --title` | `AgentGLM` | Review / re-review |
 | `kimi_claude --title` | `AgentKIMI` | Review / re-review |
 
+`init-agents` 不分配这些角色。请在当前用户 prompt 中写清期望分工。
+
 ## 使用方式
 
 ### Gateflow
 
-当你希望 Agent 从 plan 到 implementation review 和本地 ready 状态全程按 gate 推进时，使用 `gateflow`。
+`gateflow` 用于单个 work unit：feature、issue、bug fix、migration、refactor、schema/public contract change 或
+architecture-sensitive task。Gateflow 只定义 gates：preflight、goal confirmation、plan、review、implementation slices、
+fixes、aggregate deepreview、accepted commits、draft PR gate 和 final closeout。
 
-Codex:
-
-```text
-使用 $gateflow 开发 <feature>。
-如果需求不够清楚，先讨论。
-```
-
-Claude Code:
+单独使用 Gateflow 示例：
 
 ```text
-使用 /gateflow 开发 <feature>。
-如果需求不够清楚，先讨论。
+按照 $gateflow 开发 <work-unit>。
+可选设计依据：docs/host/design.md。
+先做 preflight 和 goal confirmation；用户确认目标、非目标和边界后，按 Gate Order 推进到 draft-PR-pass。
+严格遵循 AGENTS.md 的约束。
 ```
 
-`gateflow` 适合复杂任务。它会创建 plan、review plan、按 slice 实施、做 code review、跟踪 residual risk、创建本地 accepted commits，并在 `ready-to-open-draft-PR` 停下等待用户授权。用户授权 draft PR gate 后，它会自动 push、创建 draft PR、执行 PR review、fix、re-review、accepted PR review commit 和 follow-up push，直到 `draft-PR-pass`。
+Gateflow + `init-agents` 示例：
+
+```text
+按照 $gateflow 开发 <work-unit>。
+$init-agents 路由 Agents，AgentCodex 负责 plan / implement / fix，AgentMiMo / AgentDS 负责两路同时 review / re-review。
+每次发送前重新 discovery pane，clear 新任务 session，避免裸 #数字。
+严格遵循 AGENTS.md 的约束。
+```
 
 ### Phaseflow
 
-当项目有设计真源文档和实施总控文档时，使用 `phaseflow`。
+当项目有设计真源文档和实施总控文档时，使用 `phaseflow`。Phaseflow 是项目分步总控：读取当前 `phase = work unit`，
+和用户完成 preflight / goal confirmation，读取 Gateflow 的 `Gate Order`，逐 gate 派发 Agent，裁决结果，更新
+`control_doc`，并 reconcile residual risks。
 
-Codex:
-
-```text
-使用 $phaseflow，design_doc=<path/to/design.md>，control_doc=<path/to/control.md>，继续下一阶段。
-```
-
-Claude Code:
+单独使用 Phaseflow 示例：
 
 ```text
-使用 /phaseflow，design_doc=<path/to/design.md>，control_doc=<path/to/control.md>，继续下一阶段。
+按照 $phaseflow 推进，设计真源在 docs/host/design.md，总控文档是 docs/host/issues-implementation-control.md。
+先读取 control_doc 识别当前 phase/work unit，再读取 design_doc。
+总控 Agent 先完成 preflight 和 goal confirmation；用户确认后，按 Gateflow 的 Gate Order 逐 gate 派发 Agent 完成具体任务。
+每个 gate 返回后更新 control_doc、记录 artifact / finding 裁决 / residual risk。
+严格遵循 AGENTS.md 的约束。
 ```
 
-`phaseflow` 遵循 `gateflow`，并额外维护总控文档、phase 状态、风险追踪和多 Agent review 约定。
+Phaseflow + `init-agents` 示例：
+
+```text
+按照 $phaseflow 推进，设计真源在 docs/host/design.md，总控文档是 docs/host/issues-implementation-control.md。
+$init-agents 路由 Agents，AgentMiMo / AgentDS 负责两路同时 review，AgentCodex 负责 plan / implement / fix。
+总控 Agent 先做 preflight 和 goal confirmation；确认后按 Gateflow 的 Gate Order 逐 gate 派发。
+每个 Agent 返回后，总控读取 artifact、裁决 finding、更新 control_doc、收集 residual risk、关闭已解决 risk。
+严格遵循 AGENTS.md 的约束。
+```
 
 ### Planreview
 
@@ -471,7 +486,8 @@ Claude Code 使用 `/deepreview`，参数相同。
 
 ### Init Agents
 
-当你希望总控 Agent 不使用内置子 Agent，而是通过 tmux pane 向已经启动的其它 CLI Agent 派发任务时，使用 `init-agents`。
+当需要通过 tmux pane 向已经启动的 CLI Agent 发送任务时，使用 `init-agents`。它只定义通信：CLI 类型、`/skill` vs `$skill`、
+pane discovery、clear/session 规则、`tmux-cli send/wait_idle/capture` 和发送安全规则。它不分配角色。
 
 Codex:
 
@@ -485,7 +501,7 @@ Claude Code:
 使用 /init-agents 初始化多 Agent 通信约定。
 ```
 
-`init-agents` 假设 controller 只和当前 tmux session/window 可见 panes 通信，基本命令如下：
+`init-agents` 使用以下基本命令：
 
 ```bash
 tmux-cli status
@@ -545,6 +561,7 @@ skills/<skill-name>/agents/openai.yaml
 
 ## 说明
 
-- `gateflow` 和 `phaseflow` 是 controller workflows。派给 worker 的 prompt 应该是 role-scoped handoff，不应让 worker 重新启动完整 workflow。
+- `gateflow` 定义单个 work unit 的 gates。
+- `phaseflow` 是项目分步总控；具体 plan / implementation / review / fix 任务交给 Agent 完成。
 - `planreview` 和 `deepreview` 是 review skills。它们应该输出 durable artifacts，而不是只在聊天里给结论。
-- 只有在通过 tmux 同时运行多个 CLI Agent 时才需要 `init-agents`。
+- 只有在通过 tmux 路由多个 CLI Agent 时才需要 `init-agents`。

--- a/skills/gateflow/SKILL.md
+++ b/skills/gateflow/SKILL.md
@@ -1,94 +1,70 @@
 ---
 name: gateflow
-description: "开发流程编排。开发复杂 feature、migration、refactor、schema change、public contract change 或 architecture-sensitive task 时使用；流程包含可选需求讨论、code-generation-ready plan、自动 plan/code/deepreview 闭环、本地 accepted commits，并推进到 ready-to-open-draft-PR；用户授权 draft PR gate 后自动 push、创建 draft PR、PR review、fix、re-review、accepted PR review commit、push，直到 draft-PR-pass。"
+description: "单个 work unit 的 gated 开发流程。用于 feature、issue、bug fix、migration、refactor、schema/public contract change 或 architecture-sensitive task；可选接收 design document；先读代码并从第一性原理确认目标/非目标，经用户确认后按 plan、review、implementation、review、deepreview、draft PR gate 自动推进到 draft-PR-pass。"
 ---
 
 # Gateflow
 
-Gateflow 是复杂 work unit 的 controller-agent 工作流。它把 feature、migration、refactor、schema/public contract
-change 或 architecture-sensitive task，从讨论、计划、实施、review、fix、commit 推进到 `ready-to-open-draft-PR`。
-用户授权 draft PR gate 后，它继续自动 push、创建 draft PR、执行 PR review/fix/re-review、创建 accepted PR review commit
-并再次 push，直到 `draft-PR-pass`。
+Gateflow 只定义单个 `work unit` 的流程和 gate。work unit 可以是 feature、issue、bug fix、migration、refactor、
+schema/public contract change 或 architecture-sensitive task。
 
-## Role
+## Core Principles
 
-controller agent 只做总控：维护状态、派发 handoff、收集 artifact、裁决 finding、保护 scope boundary、推进 gate。
-controller 不得亲自写 plan、review、implementation、fix 或 re-review，除非用户明确要求。
+- 先看代码和事实，再判断 work unit 是否成立。
+- 进入 plan 前，先用通俗语言向用户确认目标、非目标、边界和成功信号。
+- 只做当前 work unit 需要的设计；不得引入无当前需求、真实风险或明确扩展压力支撑的过度设计。
+- 每个 gate 都必须有 artifact、decision、validation 或明确说明；conversation-only 结果不足以通过 gate。
+- draft PR gate 自动推进到 `draft-PR-pass`；merge、approve、mark ready for review、request reviewers、delete branch、
+  对外 comment、创建/修改外部 issue 仍需用户额外授权。
 
-specialist roles：
+## Invocation
 
-- planning agent：写 handoff-ready、code-generation-ready plan。
-- implementation agent：只实现 approved plan 的 assigned slice。
-- fix agent：只修 controller-accepted findings。
-- review / re-review agent：只输出 evidence-based findings 或复核结果。
-- user：回答 blocking open questions，并授权 create PR、push、merge、approve、对外 comment、创建/修改外部 issue 等对外可见动作。
+典型调用：
 
-总控裁决原则：所有 plan、review finding、fix scope、defer decision 和 residual risk 裁决，都必须追求项目内最佳实践，
-同时不得引入无当前需求、风险或明确扩展压力支撑的过度设计。
+```text
+使用 $gateflow 开发 <work-unit>。
+```
 
-## When To Use
+可选参数：
 
-用于复杂 feature、migration、大型 refactor、schema/storage/public API/state-machine change、架构敏感任务、多 Agent
-implementation/review/fix 流程。不用于 typo、小型本地 bugfix 或无须 gated orchestration 的轻量改动。
+```text
+使用 $gateflow design_doc=<path> base_ref=<ref> 开发 <work-unit>。
+```
 
-## Stop Conditions
+如果传入 `design_doc`，它是当前 work unit 的设计依据之一。若未传入，则以用户需求和代码事实为准。
 
-从 `plan` 到 `ready-to-open-draft-PR` 默认自动推进。controller 只在以下情况停下来问用户：
+## Preflight
 
-- blocking open question 影响 scope、architecture、contract、schema、file ownership、state transition、
-  implementation strategy、test expectation 或 user-visible behavior；
-- branch、dirty changes、file ownership、commit scope 不清，无法安全创建本地 checkpoint；
-- validation failure、residual risk、deferred finding、missing artifact 需要用户决策；
-- 需要首次进入 draft PR gate，也就是 push branch 并 create draft PR；
-- 需要 merge、approve、mark ready for review、request reviewers、delete branch、对外 comment 或创建/修改外部 issue。
-
-controller judgment、implementation-agent confidence 或 reviewer approval 只能推进本地 gate，不能替代用户对
-blocking open questions 或对外可见动作的授权。
-
-用户明确授权进入 draft PR gate 后，该授权覆盖本 work unit 当前分支的首次 push、create draft PR，以及 PR review/fix/re-review
-通过后的 accepted PR review commit 和 follow-up push；不覆盖 merge、approve、mark ready for review、request reviewers、
-delete branch、对外 comment 或创建/修改外部 issue。
-
-## Preflight Branch Check
-
-workflow 最开始、任何 discussion/plan/文件修改之前，必须检查：
+任何 discussion、plan 或文件修改前，先检查：
 
 ```text
 git branch --show-current
 git status --short
 ```
 
-如果当前 branch 是 `main`、`master`、`develop`、`release/*` 或项目定义的 protected trunk branch，停下来提示用户创建工作分支，
-包含当前 branch、dirty 状态、建议 branch name、确认后命令。
+如果当前 branch 是 `main`、`master`、`develop`、`release/*` 或项目定义的 protected trunk branch，先停下来让用户确认创建
+工作分支。若 branch、dirty changes 或 scope ownership 不清，也先停下来问用户。
 
-建议 branch 使用 conventional prefix：`feat/`、`fix/`、`docs/`、`refactor/`、`chore/`。确认后才执行：
+## Goal Confirmation
 
-```text
-git switch -c <suggested-branch-name>
-```
+进入 plan 前必须完成 goal confirmation：
 
-如果当前已在非 protected work branch，记录 branch 和 baseline 后继续。若 branch、dirty changes 或 worktree 状态让 scope ownership
-不清，先问用户。
+- 读取需求、design document（如有）和相关代码；
+- 从第一性原理判断 work unit 是否成立；
+- 复述目标、动机、成功信号、非目标、scope boundary；
+- 说明直接代码证据；
+- 说明本轮不会做的过度设计；
+- 列出 blocking open questions（如有）。
 
-## Invocation
-
-用户说：
-
-```text
-使用 $gateflow 开发 <feature>。
-如果需求不够清楚，先讨论。
-```
-
-controller 先判断需求是否足够写 plan。需求清楚则进入 `plan`；需求不清、动机不足、范围过大、风险高或缺少关键约束，则先
-feature discussion，收敛 goal、success signal、motivation、alternatives、tradeoffs、likely slicing、non-goals、
-stop conditions、user preferences。不要让 discussion 变成 implementation。
+用户确认后才能进入 `plan`。如果目标不成立、范围过大、动机不足或关键约束缺失，先 discussion，不进入 implementation。
 
 ## Gate Order
 
 固定顺序：
 
 ```text
-plan
+goal confirmation
+-> plan
 -> plan review
 -> fix
 -> re-review
@@ -103,7 +79,6 @@ plan
 -> re-review
 -> accepted deepreview commit
 -> ready-to-open-draft-PR
--> user authorization
 -> push
 -> create draft PR
 -> PR review
@@ -115,86 +90,49 @@ plan
 -> final closeout
 ```
 
-多 slice 时自动重复：
+多 slice 时重复：
 
 ```text
 implementation -> code review -> fix -> re-review -> accepted slice commit
 ```
 
-直到所有 approved slices 完成。除非用户明确改变 scope，不要提前进入 aggregate deepreview、ready-to-open-draft-PR、
-draft PR gate 或 closeout。
+直到所有 approved slices 完成。
 
-所有 slices commit 后，必须自动执行 aggregate deepreview：对当前 branch 相对 `main` 的完整 diff 运行
-`$deepreview --base main` / `/deepreview --base main` 等价 review。若 work unit 明确指定其它 base ref，记录原因并使用对应 base。
-aggregate deepreview 有 accepted findings 时自动 `fix -> re-review`。只有 aggregate re-review 通过并创建
-accepted deepreview commit 后，才能进入 `ready-to-open-draft-PR`。
+## Stop Conditions
 
-`ready-to-open-draft-PR` 是本地自动流程的外部动作授权点。到达后报告 branch、commits、review artifacts、
-validation results、residual risks 和 draft PR readiness，并等待用户授权进入 draft PR gate。
+除以下情况外，用户确认目标后自动推进：
 
-用户授权后，controller 自动执行 `push -> create draft PR -> PR review -> fix -> re-review -> accepted PR review commit -> push`。
-PR review 有 accepted findings 时自动进入 PR fix / PR re-review，直到没有 blocking accepted findings，才能进入
-`draft-PR-pass`。draft PR gate 内不得自动 merge、approve、mark ready for review、request reviewers、delete branch、
-对外 comment 或创建/修改外部 issue，除非用户额外授权。
+- blocking open question 影响 scope、architecture、contract、schema、file ownership、state transition、implementation strategy、
+  test expectation 或 user-visible behavior；
+- branch、dirty changes、file ownership、commit scope 不清，无法安全创建 checkpoint；
+- validation failure、unclassified residual risk、deferred finding 或 missing artifact 需要用户决策；
+- 需要 merge、approve、mark ready for review、request reviewers、delete branch、对外 comment 或创建/修改外部 issue。
 
-## Controller State
+## Plan Gate
 
-持续维护：
+plan 必须 code-generation-ready，即可以直接指导实现，不需要重新设计方案、发明契约、猜 file ownership、猜 state transition
+或决定 test scope。
 
-- work-unit name / goal / explicit non-goals；
-- current baseline and branch；
-- current gate；
-- target files/modules；
-- plan、review、implementation、fix artifact paths；
-- accepted / rejected / deferred / unresolved findings；
-- implementation slices and current slice status；
-- validation commands/results and documentation decision；
-- accepted plan commit hash、accepted slice commit hashes、accepted deepreview commit hash、accepted PR review commit hash、draft PR status；
-- residual risks、owners、tracking destinations、next entry point。
+plan 必须包含：
 
-## Protected Local Commits
+- goal / motivation / success signal；
+- non-goals / scope boundary；
+- design document alignment（如有）；
+- first-principles judgment and direct code evidence；
+- affected files/modules；
+- contract/schema/state-machine/public-interface changes；
+- implementation decisions；
+- small implementation slices；
+- tests/validation commands and expected assertions；
+- docs decision；
+- risks/open questions；
+- completion report format。
 
-Gateflow commit 是本地 accepted checkpoint，不是 push/PR/merge 授权。review loop 通过、artifact 完整且没有
-blocking open question 后，controller 自动创建：
+plan 必须显式说明为什么当前方案没有过度设计。
 
-- accepted plan commit：`plan -> plan review -> fix -> re-review` 后；
-- accepted slice commit：每个 `implementation -> code review -> fix -> re-review` 后；
-- accepted deepreview commit：`aggregate deepreview -> fix -> re-review` 后；即使没有 accepted findings，也提交
-  aggregate review artifact 和 readiness evidence。
-- accepted PR review commit：draft PR gate 内 `PR review -> fix -> re-review` 后；如无 accepted findings，则提交 PR review
-  artifact 和 pass evidence。
+## Slice Gate
 
-commit 前必须确认 branch 不是 protected trunk，检查 `git status`，只 stage 当前 gate/slice/deepreview 相关文件，
-包含相关 artifacts、validation、tests、docs，避免 unrelated dirty changes。scope 不清则停下来问用户。
-
-commit message：
-
-```text
-gateflow: accept plan for <work-unit>
-gateflow: accept <work-unit> <slice-id>
-gateflow: accept deepreview for <work-unit>
-```
-
-每次 automatic local commit 后，把 hash 记录进 controller state。进入 draft PR gate 前的 automatic local commit 禁止
-push、create PR、merge、approve 或 delete branch。draft PR gate 已获用户授权后，accepted PR review commit 后允许自动
-follow-up push；仍禁止 merge、approve、mark ready for review、request reviewers、delete branch 或对外 comment。
-
-## Plan Rules
-
-plan 必须 handoff-ready 且 code-generation-ready；implementation agent 应能直接按 plan 生成代码，不需要重新设计方案、
-发明契约、选择 file ownership、猜 state transition 或决定 test scope。
-
-plan 必须包含：goal/motivation、non-goals/scope、直接证据、affected files/modules、contract/schema/state-machine/public-interface
-changes、具体 implementation decisions、small implementation slices、tests/validation commands/expected assertions/failure paths、
-docs decision、review gates、stop conditions、risks/open questions、completion report format。
-
-blocking open questions 必须在 plan re-review 通过前解决，并作为 decision 写回 plan。planning agent 如果发现 blocking
-question，应停下来问用户或输出 `Blocking Questions For Controller`，不要把 plan 标为 handoff-ready。non-blocking questions
-必须写明 working assumption、为什么低风险、什么信号会触发回看。不要让 implementation agent 在 material options 未收敛时自行选择。
-
-## Slice Rules
-
-每个 slice 必须足够小，适合一个 implementation pass 和一个 review pass。每个 slice 写清：
+每个 slice 必须足够小，适合一次 implementation pass 和一次 review pass。每个 slice 必须写清：
 
 - id/name、objective、expected outcome；
 - allowed files/modules；
@@ -205,156 +143,87 @@ question，应停下来问用户或输出 `Blocking Questions For Controller`，
 - tests/validation commands and expected assertions；
 - completion signal and stop condition。
 
-plan review 必须要求修复 slice 太粗、file ownership 不清、implementation instructions 不够具体、tests 只在最后定义、
-sequencing 诱导 implementation agent 提前做 future-slice work 等问题。
+implementation 只能做当前 approved slice，除非 approved plan 明确允许一次做多个 slice。
 
-implementation 时只能分派当前 assigned slice，除非 approved plan 明确授权一次做多个 slice。
+## Review Gate
 
-## Residual Risk Tracking
+review / re-review 必须 evidence-based，并产出 durable artifact。finding 必须能被裁决为：
 
-每个 implementation/fix report 必须列出 residual risks 和 uncovered areas。controller 必须分类为：
+- `accepted`
+- `rejected-with-reason`
+- `deferred-with-owner`
+- `needs-more-evidence`
 
-- fixed in current slice before review；
-- covered by later slice in approved plan；
-- assigned to later phase/work unit；
+fix/re-review 最终状态只用：
+
+- `未修复`
+- `已修复`
+- `部分修复`
+- `证据失效`
+
+review gate 通过条件：
+
+- review artifact 已记录 artifact path；
+- accepted findings 都有 fix/re-review 状态；
+- re-review 已回写或列出最终 finding 状态；
+- 没有 blocking open question；
+- residual risks 已分类。
+
+## Residual Risks
+
+每个 implementation/fix/review artifact 必须列出 residual risks 和 uncovered areas。每个 residual risk 必须分类为：
+
+- fixed in current slice；
+- covered by later approved slice；
+- assigned to later work unit；
 - tracked by existing issue；
 - requiring new issue or explicit user decision。
 
-存在 unclassified residual risk 时，不得关闭 slice、code review loop、aggregate deepreview loop、PR gate 或 final closeout。
-deferred risk 必须有 owner/destination：later slice、later phase/work unit、issue number 或 user decision。
+存在 unclassified residual risk 时，不得关闭 slice、review loop、aggregate deepreview loop、PR gate 或 final closeout。
 
-## Artifact Rules
+## Artifacts
 
-除非用户明确豁免，conversation-only artifact 不足以通过 gate。
+必要 artifacts：
 
-work artifacts：
+- plan artifact；
+- plan review / re-review artifact；
+- implementation artifact for each slice；
+- code review / re-review artifact for each slice；
+- fix artifact when fixes occur；
+- aggregate deepreview / re-review artifact；
+- PR review / re-review artifact；
+- final closeout summary。
 
-- implementation artifact：每个 assigned slice 完成后、进入 code review 前；
-- fix artifact：每次 fix pass 完成后、进入 re-review 前；
-- aggregate fix artifact：aggregate deepreview 后如发生 fix；
-- PR fix artifact：PR review 后如发生 fix。
+artifact 必须记录 gate、work unit、scope、changed files 或 reviewed target、decisions/findings、validation、docs decision、
+residual risks、completion status 和 artifact path。
 
-implementation artifact 记录 gate、work-unit、slice、approved plan、scope/non-goals/allowed files、changed files、
-implemented plan items、validation、docs decision、plan gaps、residual risk classification、completion/stop status、artifact path。
+## Commits
 
-fix artifact 记录 gate、source review artifact、accepted finding ids、per-finding fix status、changed files、validation、
-new risks/open questions、residual risk classification、finding 标题状态更新结果、artifact path。
-
-review artifacts：
-
-- plan review / plan re-review；
-- code review / code re-review；
-- aggregate deepreview / aggregate re-review；
-- user-requested additional review/re-review；
-- PR review / PR re-review or fix review。
-
-review artifact 记录 gate、reviewed target、conclusion、findings、open questions/residual risk、controller decision status、
-artifact path。除非 artifact path 已进 controller state，accepted findings 都有 fix/re-review 状态，且 re-review 已在可编辑
-source review artifact 或 work log 中回写最终标题状态，否则不得标记 review gate passed。
-
-## Finding And Status Rules
-
-Plan finding：
-
-```markdown
-### 编号-未修复-[严重程度（低/中/高/严重）]-finding简述
-- **Plan位置**:
-- **问题类型**: 动机不成立 / 范围漂移 / 架构边界 / 契约缺失 / 切片过粗 / 不可直接实施 / 测试缺口 / open question 未收敛 / 其它
-- **计划当前写法**:
-- **为什么有问题**:
-- **直接证据**:
-- **影响**:
-- **建议改法和验证点**:
-- **修复风险（低/中/高）**:
-- **严重程度（低/中/高/严重）**:
-```
-
-Code/PR finding：
-
-```markdown
-### 编号-未修复-[严重程度（低/中/高/严重）]-finding简述
-- **入口/函数**:
-- **文件(行号)**:
-- **输入场景**:
-- **实际分支**:
-- **预期行为**:
-- **实际行为**:
-- **直接证据**:
-- **影响**:
-- **建议改法和验证点**:
-- **修复风险（低/中/高）**:
-- **严重程度（低/中/高/严重）**:
-```
-
-controller 必须把每个 finding 裁决为且只裁决为：`accepted`、`rejected-with-reason`、`deferred-with-owner`、
-`needs-more-evidence`。
-
-fix/re-review 标题状态词只用：`未修复`、`已修复`、`部分修复`、`证据失效`。fix agent 可先更新状态；re-review
-agent 是最终状态权威。如与 fix 自报不一致，以 re-review 为准。source artifact/work log 可编辑时，re-review
-必须回写最终标题状态；不能编辑时，re-review artifact 必须说明原因并列出最终标题状态映射。
-
-## Review Engines
-
-plan review / re-review 默认使用 `$planreview` / `/planreview`。如果目标 agent 不支持，controller 不得亲自 review；
-必须把 inline criteria 放进 handoff 派给 review agent：motivation、assumptions、scope、non-goals、success signal、
-handoff/code-generation readiness、architecture boundaries、best practices、optimal solution、overengineering、
-state machines/lifecycle/concurrency/recovery/partial failure、slice size/sequencing、tests/validation/residual tracking、
-blocking questions 是否收敛。
-
-aggregate deepreview 默认使用 `$deepreview --base main` / `/deepreview --base main`，且在 `phaseflow` 等上层 skill 覆盖时遵守其
-额外 reviewer 要求。
-
-## Worker Handoff
-
-`$gateflow` 是 controller-only workflow。worker prompt 禁止写：
+review loop 通过、artifact 完整且没有 blocking open question 后，自动创建 protected local commit：
 
 ```text
-请遵守 $gateflow
-请使用 $gateflow
-请启动 /gateflow
-follow gateflow from the beginning
+gateflow: accept plan for <work-unit>
+gateflow: accept <work-unit> <slice-id>
+gateflow: accept deepreview for <work-unit>
+gateflow: accept PR review for <work-unit>
 ```
 
-worker prompt 必须说明：这是 Gateflow-governed handoff；你不是 controller；不要启动 `$gateflow` / `/gateflow`；
-不要从 plan 重新开始；不要重排 gate；current gate；assigned scope；allowed files/modules；required validation；
-stop condition；completion report format；不得自行进入其它 gate、commit、PR、merge、push 或 closeout。
+commit 前必须确认 branch 不是 protected trunk，检查 `git status`，只 stage 当前 gate 相关文件，避免 unrelated dirty changes。
 
-worker 如果发现当前 assigned gate 信息不足，应停止并报告缺口，把控制权交回 controller。
-
-## Prompt Skeletons
-
-prompt skeletons 只是 minimum contract，controller 必须按 actual feature、repo facts、approved plan、current gate、findings
-和项目指令动态构造。
-
-- Plan：只写 plan，不改代码，不进入 implementation；输出 handoff-ready/code-generation-ready plan；blocking questions
-  走 user/ASK 或 `Blocking Questions For Controller`。
-- Plan review：只 review plan，不改代码，不进入 implementation；用 `$planreview` / `/planreview` 或 inline criteria；
-  输出 durable review artifact。
-- Implementation：只实现 assigned slice；按 approved plan、scope、allowed files、tests、docs、stop condition；输出 durable
-  implementation artifact。
-- Code review：只 review assigned slice/diff target；找 bugs、architecture violations、contract drift、missing tests、
-  type-safety、undocumented behavior changes；输出 durable review artifact。
-- Fix：只修 controller-accepted findings；不处理 rejected/deferred；不扩大 scope；报告 per-finding status，更新标题状态；
-  输出 durable fix artifact。
-- Re-review：只复核 accepted findings 及 fixes；回写最终标题状态；记录是否引入 blocker；输出 durable re-review artifact；
-  不裁决最终 gate pass。
-- Accepted commit：review loop 通过、artifact 完整、无 blocking question 后创建 protected local commit；只 stage 当前 gate/slice/deepreview
-  文件；记录 hash；不 push/PR/merge/approve/delete branch。
-
-## Draft PR Gate And Closeout
+## Draft PR Gate
 
 `ready-to-open-draft-PR` 前确认：
 
 - branch 只包含当前 work unit intended commits；
 - all approved slices 完成并有 accepted slice commits；
 - aggregate deepreview 已执行，accepted findings 已修复并 re-reviewed；
-- accepted deepreview commit 已创建并记录 hash；
+- accepted deepreview commit 已创建；
 - tests/type checks 已运行或失败已说明；
 - docs decision 已完成；
 - deferred findings/residual risks 有 owner/destination；
 - draft PR summary 匹配真实代码，不把 future work 写成已完成。
 
-到达 `ready-to-open-draft-PR` 后停止并报告 readiness。用户明确授权后，controller 自动：
+到达 `ready-to-open-draft-PR` 后自动：
 
 ```text
 push
@@ -367,11 +236,17 @@ push
 -> draft-PR-pass
 ```
 
-PR review 有 accepted findings 时，必须自动修复并 re-review；re-review 通过前不得进入 `draft-PR-pass`。accepted PR
-review commit 后必须自动 push，让 draft PR 反映最终通过状态。PR review 若无 accepted findings，也必须提交 PR review
-artifact / pass evidence 并 push。
+PR review 有 accepted findings 时，必须自动修复并 re-review。PR review 若无 accepted findings，也必须提交 PR review artifact /
+pass evidence 并 push。
 
-`draft-PR-pass` 后进入 final closeout。final closeout 仍不得自动 merge、approve、mark ready for review、request reviewers、
-delete branch、对外 comment 或创建/修改外部 issue；这些动作都需要用户额外授权。
+## Final Closeout
 
-final closeout 说明 what changed、what was verified、docs updates、finding status、remaining risks/owners、next entry point。
+`draft-PR-pass` 后输出 final closeout：
+
+- what changed；
+- what was verified；
+- docs updates；
+- finding status；
+- remaining risks / owners；
+- draft PR URL；
+- next entry point。

--- a/skills/init-agents/SKILL.md
+++ b/skills/init-agents/SKILL.md
@@ -1,34 +1,21 @@
 ---
 name: init-agents
-description: "初始化多 Agent 通信约定。用于总控流程在通过 tmux pane 派发任务前确认 AgentMiMo、AgentDS、AgentGLM、AgentOpus、AgentCodex 的 CLI 类型、推荐任务类型、/skill 或 $skill prompt 写法、pane 发现方式、清 session 方式和 tmux-cli send/wait_idle/capture 流程。"
+description: "初始化多 Agent tmux 通信约定。用于确认 Agent CLI 类型、/skill 或 $skill 写法、pane discovery、clear/session 规则，以及 tmux-cli send/wait_idle/capture 流程。"
 ---
 
 # Init Agents
 
-## Purpose
+Init Agents 只定义多 Agent 通信步骤和安全规则。
 
-`init-agents` 负责加载多 Agent 通信约定：每个 Agent 属于哪类 CLI、推荐处理什么任务、发送 prompt 时用什么技能触发格式、
-发送前如何确认 pane、何时清 session。具体项目或流程里的最终职责由用户当前任务、`$gateflow`、`$phaseflow`
-或其它上层 skill 决定。
+## Agent CLI Types
 
-## Agent Map
-
-| Agent | CLI type | Recommended task type |
+| Agent | CLI type | Skill trigger |
 | --- | --- | --- |
-| `AgentMiMo` | Claude Code Agent | review / re-review |
-| `AgentDS` | Claude Code Agent | review / re-review |
-| `AgentGLM` | Claude Code Agent | review / re-review |
-| `AgentOpus` | Claude Code Agent | implementation / fix |
-| `AgentCodex` | Codex Agent | implementation / fix |
-
-Routing priority:
-
-1. 用户或上层 skill 的明确分工优先。
-2. 没有明确分工时，按上表选择适合任务类型的 Agent。
-3. Agent 是否在线只影响可用性，不应让 review-only Agent 接 implementation / fix，也不应让 implementation/fix
-   Agent 接 review / re-review，除非用户或上层 skill 明确授权。
-
-## Prompt Syntax
+| `AgentMiMo` | Claude Code Agent | slash command |
+| `AgentDS` | Claude Code Agent | slash command |
+| `AgentGLM` | Claude Code Agent | slash command |
+| `AgentOpus` | Claude Code Agent | slash command |
+| `AgentCodex` | Codex Agent | dollar skill |
 
 Claude Code Agent 使用 slash command：
 
@@ -46,49 +33,27 @@ $deepreview
 $gateflow
 ```
 
-派发 role-scoped worker handoff 时，不要让 worker 重新启动完整 workflow。也就是说，implementation / fix /
-review worker prompt 里应写清 current gate、assigned scope、allowed files/modules、artifact path、stop condition，
-而不是只写“使用 `$gateflow`”或“启动 `/gateflow`”。
+## Pane Discovery
 
-如果目标 Agent 环境不支持对应 skill/slash command，controller 应把关键 criteria 内联进 handoff prompt，
-不要只写 skill 名称。
-
-## Tmux Pane Discovery
-
-每次实际通信前，必须用两步 discovery 确认目标 Agent 的当前 full pane id：
+每次发送前都重新确认目标 full pane id：
 
 ```bash
 tmux-cli status
 tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{window_name} #{pane_current_command} #{pane_title}'
 ```
 
-第一步用 `tmux-cli status` 确认当前 tmux 上下文。第二步用 `tmux list-panes -a` 获取跨 window 的 full pane id。
-查找到目标 Agent 后，记录 full pane id，例如：
+使用跨 window 的 full pane id，例如：
 
 ```text
 ai-2:1.3
 ```
 
-后续 `tmux-cli send`、`tmux-cli wait_idle`、`tmux-cli capture` 都使用这个 full pane id。
-
-要求：
-
-- 每次发送前都重新执行两步 discovery 并确认目标 full pane id，即使刚刚确认过。
-- 后续统一使用 full pane id，避免发错目标。
-- 如果目标 Agent 不在线、pane id 不明确、名称冲突、命令不可用，先停下来向用户报告，不要盲发 prompt。
+后续 `tmux-cli send`、`tmux-cli wait_idle`、`tmux-cli capture` 都使用 full pane id。若目标 Agent 不在线、pane id 不明确、
+名称冲突或命令不可用，先报告，不要盲发。
 
 ## Session Clear
 
-确认目标 full pane id 后，如果这是新的 assigned task 或新的 gate/slice，先向目标 pane 发送清 session 命令，再发送正式
-handoff prompt。
-
-Claude Code Agent 使用：
-
-```text
-/clear
-```
-
-Codex Agent 使用：
+新 assigned task 或新的 gate/slice，先发送 clear，再发送正式任务：
 
 ```text
 /clear
@@ -96,30 +61,28 @@ Codex Agent 使用：
 
 要求：
 
-- 等目标 Agent 完成 clear 并回到可输入状态后，再发送正式 handoff prompt；
-- 不要把 clear 命令和正式任务 prompt 合并发送；
-- 如果 clear 失败、目标 Agent 没有回到可输入状态，先停下来报告。
+- clear 和正式任务分开发送；
+- 等目标 Agent 完成 clear 并回到可输入状态后，再发送正式任务；
+- clear 失败或目标未回到可输入状态时，先报告。
 
-例外：如果判断该目标 Agent 当前 assigned task 尚未全部完成，正在等待补充信息、继续执行、返回 artifact、
-修正同一轮输出或回答同一任务 follow-up，则不能 clear。此时保留现有 session，直接发送与当前未完成任务相关的补充指令。
+如果目标 Agent 当前任务尚未完成，正在等待补充信息、继续执行、返回 artifact、修正同一轮输出或回答同一任务 follow-up，
+不要 clear，直接发送补充指令。
 
-## Tmux Send Text Safety
+## Send Safety
 
-通过 `tmux-cli send` 发送 handoff prompt 时，避免正文中使用裸 `#数字`，某些环境会把 `PR #45` 这类文本截断。
+通过 `tmux-cli send` 发送文本时，避免裸 `#数字`，某些环境会截断 `PR #45` 这类文本。
 
-写法要求：
+写法：
 
-- 不写 `PR #45`、`issue #123`；
-- 改写为 `PR 45`、`PR-45`、`Pull Request 45`、`issue 123` 或 `issue-123`；
-- 如果需要保留 GitHub URL，优先写完整 URL，而不是依赖 `#数字`；
-- 如果发现目标 Agent 只收到截断内容，这属于同一未完成 assigned task 的补充场景，不要 clear；刷新
-  `tmux-cli status` 后重新发送去掉 `#数字` 的完整 handoff。
+- 用 `PR 45`、`PR-45`、`Pull Request 45`；
+- 用 `issue 123`、`issue-123`；
+- 需要链接时写完整 URL。
 
-## Agent Chat Workflow
+如果发现内容被截断，不要 clear；重新 discovery 后发送去掉裸 `#数字` 的完整文本。
 
-与其它 CLI Agent 通信时，使用 `tmux-cli send` + `tmux-cli wait_idle` + `tmux-cli capture`。
+## Chat Workflow
 
-新 assigned task 的标准流程：
+新 assigned task：
 
 ```bash
 tmux-cli status
@@ -127,35 +90,31 @@ tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{window_na
 tmux-cli send "/clear" --pane=<full-pane-id>
 tmux-cli wait_idle --pane=<full-pane-id> --idle-time=3 --timeout=60
 tmux-cli capture --pane=<full-pane-id>
-tmux-cli send "<handoff prompt>" --pane=<full-pane-id>
+tmux-cli send "<task text>" --pane=<full-pane-id>
 tmux-cli wait_idle --pane=<full-pane-id> --idle-time=3 --timeout=<task-timeout-seconds>
 tmux-cli capture --pane=<full-pane-id>
 ```
 
-未完成 assigned task 的补充流程：
+未完成 task 的 follow-up：
 
 ```bash
 tmux-cli status
 tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{window_name} #{pane_current_command} #{pane_title}'
-tmux-cli send "<follow-up prompt>" --pane=<full-pane-id>
+tmux-cli send "<follow-up text>" --pane=<full-pane-id>
 tmux-cli wait_idle --pane=<full-pane-id> --idle-time=3 --timeout=<task-timeout-seconds>
 tmux-cli capture --pane=<full-pane-id>
 ```
 
-`tmux-cli execute` 只用于 shell command 且需要 exit code 的场景，例如测试、构建或脚本执行；不要用
-`tmux-cli execute` 做 agent-to-agent chat。
+`tmux-cli execute` 只用于需要 exit code 的 shell command；不要用于 agent-to-agent chat。
 
-## Handoff Checklist
+## Checklist
 
-每次向任何 Agent 发送 prompt 前，必须：
+发送前确认：
 
-1. 运行 `tmux-cli status` 确认当前 tmux 上下文；
-2. 运行 `tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{window_name} #{pane_current_command} #{pane_title}'` 确认跨 window 的目标 full pane id；
-3. 判断这是新任务还是未完成任务 follow-up；新任务先 clear，未完成任务不 clear；
-4. 检查 prompt 文本，避免裸 `#数字`；
-5. 确认目标 Agent 的 recommended task type 与当前任务匹配，或确认用户/上层 skill 明确授权了该分工；
-6. 按目标 Agent 类型选择 `/skill` 或 `$skill`；
-7. 写清 role-scoped handoff：current gate、assigned scope、allowed files/modules、artifact path、stop condition；
-8. 明确 worker 不 commit、不 push、不 PR、不进入其它 gate，除非用户或上层流程明确授权。
-
-如果目标 Agent 不可用，不要假装已经派发；报告不可用证据，并只在职责匹配或已获授权的 Agent 中选择替补，否则询问用户。
+- 已运行 `tmux-cli status`；
+- 已运行 `tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{window_name} #{pane_current_command} #{pane_title}'`；
+- 已确认目标 full pane id；
+- 已判断是否需要 clear；
+- 已避免裸 `#数字`；
+- 已按目标 CLI 类型选择 `/skill` 或 `$skill`；
+- 发送后使用 `wait_idle` 和 `capture` 读取结果。

--- a/skills/phaseflow/SKILL.md
+++ b/skills/phaseflow/SKILL.md
@@ -199,7 +199,7 @@ implementation -> code review -> fix -> re-review -> accepted slice commit
 - aggregate deepreview/re-review 通过后：aggregate review artifact、accepted deepreview commit hash；
 - ready-to-open-draft-PR 前：draft PR readiness、剩余风险、owner、后续 phase/work unit destination；
 - draft-PR-pass 后：draft PR URL、PR review artifacts、accepted PR review commit hash、follow-up push 状态、remaining risks /
-  owners、当前 phase/work unit 完成状态、next entry point。
+  owners、当前 phase/work unit 完成状态、issue 更新/关闭状态（如当前 work unit 是 issue）、next entry point。
 
 如果 `control_doc` 没有合适位置记录这些内容，先提出具体写入位置或结构。
 
@@ -209,7 +209,9 @@ implementation -> code review -> fix -> re-review -> accepted slice commit
 
 - 收集 final closeout、review artifacts、fix artifacts 和裁决记录中的 residual risks；
 - 为仍存在的 residual risk 写入 owner、destination、后续 phase/work unit、issue 或 user decision；
-- 删除、关闭或标记已解决的历史 residual risk；
+- 删除已 close 的 residual risk；
+- 对已解决但尚未 close 的 residual risk，关闭或标记已解决；
+- 如果当前 work unit 是 issue，更新对应 issue；若该 issue 已完成，close issue；
 - 确认 next entry point 指向用户 merge 当前 PR 后可以直接进入的下一个 phase/work unit。
 
 存在没有 owner/destination 的 residual risk 时，不得关闭 phase/work unit。

--- a/skills/phaseflow/SKILL.md
+++ b/skills/phaseflow/SKILL.md
@@ -1,17 +1,16 @@
 ---
 name: phaseflow
-description: "基于两个参数文档驱动 phase 开发总控：design_doc 作为设计真源，control_doc 作为实施总控文档；遵循 $gateflow / /gateflow 和 $init-agents / /init-agents 的多 Agent 约定，推进 phase design、plan、implementation、review、risk tracking 和 ready-to-open-draft-PR；用户授权后继续推进 draft PR gate 到 draft-PR-pass。用户说按总控文档开发 phase、继续下一阶段、使用 phaseflow 或给出设计文档和总控文档时使用。"
+description: "项目分步总控。基于 design_doc 和 control_doc 推进 phase/work unit；phase = work unit，每个 phase 可是 feature、issue 或 bug fix；总控读取 Gateflow 的 Gate Order，自己完成 preflight 和 goal confirmation，然后按固定 gate 顺序派发 Agent 完成具体 plan/implementation/review/fix，裁决结果、更新 control_doc、追踪 residual risk。"
 ---
 
 # Phaseflow
 
-## Purpose
+Phaseflow 是项目分步总控。定义：`phase = work unit`。一个 phase/work unit 可以是 feature、issue、bug fix 或其它单个可交付开发单元。
 
-`phaseflow` 是 `$gateflow` / `/gateflow` 的项目 phase 总控 wrapper。它不替代 `$gateflow`，而是在给定
-`design_doc` 和 `control_doc` 后，规定 controller 如何读取设计真源、维护总控状态、派发多 Agent、裁决 review
-结果，并把遗留问题和潜在风险追踪到总控文档或后续 phase。
+Phaseflow 只做总控任务；除总控任务外的具体任务必须交给 Agent 完成。用户只和 phaseflow 总控交互，其它 Agent 都通过
+phaseflow handoff。
 
-## Invocation
+## Inputs
 
 推荐调用：
 
@@ -25,174 +24,202 @@ $phaseflow design_doc=docs/host/design.md control_doc=docs/host/implementation-c
 $phaseflow docs/host/design.md docs/host/implementation-control.md
 ```
 
-参数含义：
+- `design_doc`：设计真源，用于裁决目标、边界、架构、契约、非目标和 review finding。
+- `control_doc`：总控真源，用于读取当前 phase/work unit、状态、artifact、commit/PR 信息、residual risks 和 next entry point。
 
-- `design_doc`：设计真源。所有 phase design、plan 裁决和 review 裁决必须以它为核心依据之一。
-- `control_doc`：总控文档。用于读取当前 phase 状态、目标、追踪项、遗留问题、潜在风险和下一步入口；phase
-  结束时必须及时更新。
+缺少任一文档、路径不明确或无法读取时，先停下来询问。
 
-如果两个文档缺失、路径不明确或无法读取，先停下来询问，不要进入 `$gateflow`。
+## Controller Scope
 
-## Startup Contract
+允许亲自做的总控任务：
 
-启动后第一步必须先读取 `control_doc`，再按需要读取 `design_doc`。读完后先回复用户，不能直接开始实现。
+- 读取 `control_doc`、`design_doc`、artifact、diff、review 结果；
+- 读取 Gateflow 的 `Gate Order` 和 gate 规则；
+- 识别当前 phase/work unit、当前 gate、next entry point；
+- 执行 preflight；
+- 执行 goal confirmation；
+- 复述当前目标、非目标、约束、风险和下一步；
+- 生成交给 Agent 的任务说明；
+- 派发 Agent、等待结果、读取结果；
+- 裁决 accepted / rejected / deferred / needs-more-evidence findings；
+- 更新 `control_doc` 的状态、artifact、commit hash、PR 信息、finding 裁决、residual risk、next entry point；
+- 做 branch/status 检查、创建 accepted local commit、记录验证结果等 gate bookkeeping。
 
-首次回复必须包含：
+必须交给 Agent 的具体任务：
 
-- 当前从 `control_doc` 识别出的 phase / work unit；
-- 接下来应进入哪一步：discussion、plan、implementation、aggregate deepreview、ready-to-open-draft-PR、draft PR gate、draft-PR-pass 或其它；
-- 将如何使用 `design_doc` 和 `control_doc`；
-- 将如何派发 Agent；
-- 将如何做 review 裁决、风险追踪和总控状态更新；
-- 如果存在疑问，列出 blocking open questions。
+- code-generation-ready plan；
+- implementation；
+- fix；
+- review / re-review；
+- aggregate deepreview；
+- PR review / re-review；
+- source code、tests、migration、schema、配置、运行时行为或产品功能文档修改。
 
-如果已经知道下一步、知道怎么做，简短复述并等待或继续执行用户明确授权的动作；如果有疑问，先提问。
+如果具体任务没有可用 Agent 或职责不清，先停下来报告，不要自己补做。
 
-## Controller Role
+## Startup
 
-controller 是总控 Agent。除 `$gateflow` 已定义的职责外，还必须：
+启动后先读取 `control_doc`，再按需要读取 `design_doc`，并读取 Gateflow 的 `Gate Order`。首次回复必须包含：
 
-- 始终保持 controller 身份：默认动作是读取、派发、等待、裁决、记录、维护总控状态和推进 gate，而不是亲自执行
-  specialist work；
-- 在读懂 `design_doc` 的基础上裁决 plan review、code review、aggregate deepreview 和 PR review 结果；
-- 对每个 accepted / rejected / deferred / needs-more-evidence finding 形成 durable 裁决记录；
-- 维护 `control_doc` 中的 phase 状态、已完成项、当前 gate、artifact 路径、commit hash、review 结论和 next entry point；
-- 每个 phase 开发结束后，把遗留问题和潜在风险写入 `control_doc`，或明确指定到后续 phase / issue / owner；
-- `ready-to-open-draft-PR` 前，`control_doc` 必须更新为当前 phase 完成，且所有 tracking items 都有明确 owner。
+- 当前 phase/work unit；
+- 它属于 feature、issue、bug fix 还是其它可交付单元；
+- 当前 gate / next entry point；
+- Gateflow `Gate Order` 中下一步对应的 gate；
+- 将派发给哪个 Agent 做下一步具体任务；
+- 将如何使用 `design_doc` 和 `control_doc` 裁决结果；
+- blocking open questions（如有）。
 
-controller 不得亲自执行 specialist work，除非用户明确要求；必须按 `$gateflow` / `/gateflow` 约束派发
-planning、implementation、fix、review 和 re-review handoff。
+## Preflight
 
-### Controller Invariant
-
-`phaseflow` 激活期间，controller 必须把“我是总控”视为持续不变量，而不是启动阶段的一次性说明。长时间运行、
-上下文压缩、Agent 返回、review loop 切换或用户补充信息后，都必须回到这个不变量校验下一步动作。
-
-controller 允许亲自执行的工作默认只包括：
-
-- 阅读 `control_doc`、`design_doc`、plan、artifact、diff 和 review 结果；
-- 编写或更新 controller artifact、handoff、review decision、risk tracking、status log；
-- 更新 `control_doc` 中的 phase 状态、gate、artifact、commit hash、finding 裁决、residual risk 和 next entry point；
-- discussion / design 阶段维护 `design_doc`，包括澄清目标、架构边界、状态机、契约、非目标、phase 切分和设计裁决；
-- 为保护 gate 所需的非 implementation 操作，例如检查 branch/status、创建 accepted local commit、记录验证结果。
-
-controller 默认不得亲自执行以下 specialist work，除非用户明确授权 controller 直接做：
-
-- implementation / fix，包括修改 source code、tests、migration、schema、配置、运行时行为或产品功能文档；
-- planning agent 应交付的 code-generation-ready plan；
-- review / re-review agent 应交付的独立 review 结论；
-- 让 implementation agent 自行完成的验证、修复和 completion report。
-
-### Before Any Edit Or Command Guard
-
-在任何可能改变文件、提交、运行验证、推进 gate 或派发下一步的动作前，controller 必须先做一次简短自检：
+任何 discussion、plan、派发或文件修改前，phaseflow 总控先执行与 Gateflow 相同的 preflight：
 
 ```text
-Am I about to do controller work or specialist work?
-
-Controller work:
-- control_doc update
-- design_doc update during discussion/design
-- controller artifact / handoff / decision / risk tracking
-- gate bookkeeping, accepted local commit, status update
-
-Specialist work:
-- source/test/config/migration/schema/runtime behavior changes
-- implementation/fix/review/re-review/planning deliverables
-
-If specialist work, delegate it through the current gate's handoff unless the user explicitly authorized controller to do it.
+git branch --show-current
+git status --short
 ```
 
-如果动作类型不清楚，controller 必须先把它分类并记录原因；不能在分类不明时直接改代码或测试。
+如果当前 branch 是 `main`、`master`、`develop`、`release/*` 或项目定义的 protected trunk branch，先停下来让用户确认创建
+工作分支。若 branch、dirty changes 或 scope ownership 不清，也先停下来问用户。
 
-### Resume Protocol
+## Goal Confirmation
 
-每次 resume、上下文压缩后继续、Agent 返回、review loop 结束、进入新 gate 或准备修改文件前，controller 必须快速恢复状态：
+进入 Gate Order 的 `plan` 前，phaseflow 总控先完成 goal confirmation：
 
-- 重新确认当前 gate、phase、work unit 和 next entry point，优先从 `control_doc` 读取；
-- 明确复述一次：当前我是 controller，下一个 specialist work 必须派发，除非用户明确授权我亲自执行；
-- 判断下一步动作属于 controller allowlist 还是 specialist work；
-- 如果是 specialist work，先产出或更新 handoff，并派发给合适 Agent；
-- 如果是 controller work，执行后把状态、风险、finding 裁决或 artifact 路径写回 `control_doc` 或 controller artifact。
+- 读取 `control_doc`、`design_doc` 和相关代码；
+- 从第一性原理判断当前 phase/work unit 是否成立；
+- 向用户复述目标、动机、成功信号、非目标、scope boundary；
+- 说明直接代码证据；
+- 说明本轮不会做的过度设计；
+- 列出 blocking open questions（如有）。
 
-## Agent Routing
+用户确认后，phaseflow 才能派发 `plan` gate。目标不成立、范围过大、动机不足或关键约束缺失时，先 discussion，不派发具体任务。
 
-使用 `$init-agents` / `/init-agents` 获取当前 Agent 通信和 pane 规则。若与本 skill 有冲突，以本 skill 的
-phase routing 为准，并记录原因。
+## Agent Dispatch
 
-默认路由：
+派发前必须写清：
 
-- implementation / fix：`AgentCodex` 和 `AgentOpus` 可任选其一。若需要并行实施，必须先确认 file ownership
-  互不重叠，并由 controller 明确拆分 scope。
-- review / re-review：`AgentMiMo`、`AgentDS`、`AgentGLM` 可任选其二，形成两份独立 review；controller 负责整合、
-  去重和裁决 findings。
+- 当前 phase/work unit；
+- 当前 gate；
+- `design_doc` 路径；
+- 目标、非目标、scope boundary；
+- 从 `control_doc` 提炼出的当前 gate 约束和风险；
+- allowed files/modules；
+- expected artifact path；
+- required validation；
+- stop condition；
+- completion report format；
+- 禁止 commit、push、PR、merge、进入其它 gate，除非当前任务明确要求。
 
-如果某个 Agent 不在，controller 必须记录不可用事实，并选择可用 Agent 替补或询问用户。
+如果用户指定 Agent，就按用户指定。若用户要求使用 `$init-agents` / `/init-agents`，按其通信规则确认 pane、clear、send、wait、capture。
 
-## Gateflow Differences
+并行派发前必须确认 file ownership 不重叠。
 
-除非本节明确覆盖，其余全部遵循 `$gateflow` / `/gateflow`。
+## Gate Order Dispatch
 
-与普通 `$gateflow` 的差异：
+phaseflow 必须读取 Gateflow 中 `Gate Order` 定义，并按其中固定顺序总控当前 phase/work unit。不要把整个 work unit 交给其它
+Agent 启动完整 Gateflow；phaseflow 自己维护 current gate，并逐 gate 派发具体任务。
 
-- `design_doc` 是设计真源，`control_doc` 是总控真源；所有 plan、review 裁决和 phase 状态必须回到这两个文档校验。
-- design 和 plan 裁决的核心问题是：是否以最佳实践保证 `design_doc` 和/或 `control_doc` 中设计目标达成，同时不引入过度设计。
-- `ready-to-open-draft-PR` 前的 aggregate review 必须从 `AgentMiMo`、`AgentDS`、`AgentGLM` 中任选其二同时做。
-  若无法取得至少两份独立 aggregate review，必须记录原因，并说明是否需要用户接受单 reviewer 风险。
-- controller 必须维护 phase 级遗留问题和潜在风险追踪，不允许把 residual risk 停留在 conversation-only 状态。
-- `ready-to-open-draft-PR` 前，`control_doc` 必须更新为当前 phase 完成，且所有 tracking items 都有明确 owner。
-- 用户授权进入 draft PR gate 后，controller 继续遵循 `$gateflow` / `/gateflow` 自动推进 push、create draft PR、
-  PR review、fix、re-review、accepted PR review commit、push，直到 `draft-PR-pass`；merge、approve、mark ready for review、
-  request reviewers、delete branch、对外 comment 或创建/修改外部 issue 仍需额外授权。
-
-## Review Judgment Lens
-
-controller 做 design / plan / review finding 裁决时，最高优先级依据是 `design_doc` 中的“设计目标”。裁决不是按
-implementation agent 的偏好、reviewer 的风格建议或局部代码便利性投票，而是依照第一性原理判断：什么方案最直接、稳健、
-可维护地达成设计目标，同时满足当前 phase 的 scope、约束和非目标。
-
-如果 `design_doc` 路径是项目约定的 `docs/host/design.md`，必须优先回到该文档的“设计目标”章节校验裁决；如果调用时传入
-其它 `design_doc`，则以传入文档中的等价设计目标章节为准。找不到明确设计目标时，controller 必须先补充或澄清设计目标，
-不能把 review finding 或 implementation 便利性当成事实上的目标。
-
-controller 裁决 design / plan / review finding 时，必须显式考虑：
-
-- 是否满足 `control_doc` 的 phase 目标和 success signal；
-- 是否符合 `design_doc` 的架构边界、状态机、契约和非目标；
-- 是否直接服务于 `design_doc` 的“设计目标”，而不是只优化局部实现、短期便利或 reviewer 个人偏好；
-- 是否采用项目内最佳实践来达成目标；
-- 是否引入过度设计、过度耦合或把本应基于 Protocol / interface 的结构设计成基于具体实现；
-- 是否让后续 phase 更难推进、让 residual risk 后移但无 owner，或让 implementation agent 需要重新设计。
-
-每个 accepted / rejected / deferred / needs-more-evidence 裁决都必须能用一句话说明：
+以读取到的 Gateflow `Gate Order` 为准；当前定义为：
 
 ```text
-基于 design_doc 的设计目标和第一性原理，为什么这个裁决是当前 phase 的最佳实践选择？
+goal confirmation
+-> plan
+-> plan review
+-> fix
+-> re-review
+-> accepted plan commit
+-> implementation
+-> code review
+-> fix
+-> re-review
+-> accepted slice commit
+-> aggregate deepreview
+-> fix
+-> re-review
+-> accepted deepreview commit
+-> ready-to-open-draft-PR
+-> push
+-> create draft PR
+-> PR review
+-> fix
+-> re-review
+-> accepted PR review commit
+-> push
+-> draft-PR-pass
+-> final closeout
 ```
 
-## Control Document Updates
-
-每个 phase 关键点都要更新或准备更新 `control_doc`：
-
-- plan/re-review 通过后：记录 plan artifact、plan review artifacts、accepted plan commit hash；
-- 每个 slice commit 后：记录 slice 状态、artifact、review 结论、commit hash、未覆盖项；
-- aggregate deepreview/re-review 通过后：记录 aggregate review artifact、accepted deepreview commit hash；
-- ready-to-open-draft-PR 前：把当前 phase 标记为完成，记录 draft PR readiness、剩余风险、owner、后续 phase / issue destination。
-- draft-PR-pass 后：记录 draft PR URL、PR review artifacts、accepted PR review commit hash、follow-up push 状态、
-  remaining risks / owners 和 next entry point。
-
-如果 `control_doc` 没有合适位置记录这些内容，controller 必须提出具体写入位置或结构，不要跳过。
-
-## Initial Prompt Skeleton
-
-当用户只给出两个文档并要求开始时，controller 应按这个意图执行：
+多 slice 时重复：
 
 ```text
-接下来遵循 $gateflow / /gateflow 开始开发。
-设计真源在 <design_doc>，总控文档是 <control_doc>。
-先阅读总控文档，再按需要阅读设计真源。
-你是总控 Agent：负责派发 Agent、裁决 review、形成裁决文档、维护遗留问题和风险追踪、更新总控状态。
-AgentCodex / AgentOpus 可任选其一用于 implementation / fix；AgentMiMo / AgentDS / AgentGLM 可任选其二用于 review / re-review，aggregate review 必须至少两者同时做。
-design 和 plan 裁决重点考虑：最佳实践是否保证总控文档中的设计目标达成，且不引入过度设计。
-请先读 control_doc 后复述你知道的下一步；有疑问先提问。
+implementation -> code review -> fix -> re-review -> accepted slice commit
 ```
+
+每次派发 Agent 的任务说明只包含该 gate 所需的信息：
+
+- work unit 名称和类型；
+- `design_doc` 路径；
+- 目标、非目标、success signal、约束和风险；
+- current gate；
+- allowed files/modules；
+- accepted findings（fix / re-review gate）；
+- expected artifact path；
+- required validation；
+- stop condition；
+- completion report format；
+- 禁止 commit、push、PR、merge、进入其它 gate，除非当前 gate 明确要求。
+
+每个 Agent 返回后，phaseflow 读取 artifact，裁决结果，更新 `control_doc`，再进入下一个 gate。
+
+## Judgment
+
+裁决 plan、review finding、fix scope、defer decision 和 residual risk 时，优先依据：
+
+- `design_doc` 的设计目标；
+- `control_doc` 的当前 phase 目标和 success signal；
+- 项目内最佳实践；
+- 当前 phase 的 scope、约束和非目标；
+- 不引入过度设计。
+
+每个 finding 必须裁决为且只裁决为：
+
+- `accepted`
+- `rejected-with-reason`
+- `deferred-with-owner`
+- `needs-more-evidence`
+
+每个裁决必须能说明：为什么这是当前 phase 的最佳实践选择。
+
+## Control Doc Updates
+
+每个关键点都要更新或准备更新 `control_doc`：
+
+- plan/re-review 通过后：plan artifact、plan review artifacts、accepted plan commit hash；
+- 每个 slice commit 后：slice 状态、artifact、review 结论、commit hash、未覆盖项；
+- aggregate deepreview/re-review 通过后：aggregate review artifact、accepted deepreview commit hash；
+- ready-to-open-draft-PR 前：draft PR readiness、剩余风险、owner、后续 phase/work unit destination；
+- draft-PR-pass 后：draft PR URL、PR review artifacts、accepted PR review commit hash、follow-up push 状态、remaining risks /
+  owners、当前 phase/work unit 完成状态、next entry point。
+
+如果 `control_doc` 没有合适位置记录这些内容，先提出具体写入位置或结构。
+
+## Residual Risk Reconciliation
+
+每个 phase/work unit 完成后必须：
+
+- 收集 final closeout、review artifacts、fix artifacts 和裁决记录中的 residual risks；
+- 为仍存在的 residual risk 写入 owner、destination、后续 phase/work unit、issue 或 user decision；
+- 删除、关闭或标记已解决的历史 residual risk；
+- 确认 next entry point 指向用户 merge 当前 PR 后可以直接进入的下一个 phase/work unit。
+
+存在没有 owner/destination 的 residual risk 时，不得关闭 phase/work unit。
+
+## Resume
+
+每次 resume、上下文压缩后继续、Agent 返回、review loop 结束、进入新 gate 或准备修改文件前，先恢复状态：
+
+- 重新读取或确认 `control_doc` 中的当前 phase/work unit；
+- 确认 current gate 和 next entry point；
+- 判断下一步是总控任务还是具体任务；
+- 总控任务自己做并写回 `control_doc`；
+- 具体任务派发给 Agent。


### PR DESCRIPTION
## Summary

- Simplify `gateflow` into a concise gated workflow definition for a single work unit.
- Simplify `init-agents` into tmux communication rules only.
- Refocus `phaseflow` as project step controller that reads Gateflow gate order, handles preflight and goal confirmation, delegates concrete work to Agents, and updates `control_doc` / residual risks.

## Validation

- Ran `git diff --check` for the updated skill files.