### PR TITLE
[codex] prevent phaseflow from stopping active agents

### DIFF
--- a/skills/gateflow/SKILL.md
+++ b/skills/gateflow/SKILL.md
@@ -90,6 +90,8 @@ goal confirmation
 -> final closeout
 ```
 
+`plan review` gate 必须使用 `planreview` skill；`code review`、`aggregate deepreview` 和 `PR review` gates 必须使用 `deepreview` skill。
+
 多 slice 时重复：
 
 ```text

--- a/skills/phaseflow/SKILL.md
+++ b/skills/phaseflow/SKILL.md
@@ -112,6 +112,8 @@ git status --short
 
 如果用户指定 Agent，就按用户指定。若用户要求使用 `$init-agents` / `/init-agents`，按其通信规则确认 pane、clear、send、wait、capture。
 
+总控派发 Agent 后，若有证据表明 Agent 在工作、或 Agent 所在的 pane 的显示在变化，不得擅自停止该 gate。
+
 并行派发前必须确认 file ownership 不重叠。
 
 ## Gate Order Dispatch

--- a/skills/phaseflow/SKILL.md
+++ b/skills/phaseflow/SKILL.md
@@ -151,6 +151,8 @@ goal confirmation
 -> final closeout
 ```
 
+`plan review` gate 必须使用 `planreview` skill；`code review`、`aggregate deepreview` 和 `PR review` gates 必须使用 `deepreview` skill。
+
 多 slice 时重复：
 
 ```text


### PR DESCRIPTION
## Summary

- Add a Phaseflow dispatch constraint preventing the controller from stopping a gate when there is evidence the assigned Agent is still working or its pane display is changing.

## Validation

- Ran `git diff --check -- skills/phaseflow/SKILL.md`.