### PR TITLE
fix: use python3 in validator and document pyyaml dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ status, validation result, and residual risk.
 ## Requirements
 
 - Codex CLI, Claude Code, or another agent runtime that supports local skill-style instruction files.
-- Python 3.11+ if you want to run the bundled skill validator.
+- Python 3.11+ (invoked as `python3`) and the `pyyaml` package if you want to run the bundled skill validator.
 - `tmux` and `tmux-cli` if you use `init-agents` for multi-agent handoff.
 
 If you use the zsh agent launcher functions below, their `tmux select-pane -T` calls rely on stable pane titles. Add this to `~/.tmux.conf` first so running programs cannot overwrite the title:
@@ -94,6 +94,14 @@ Clone the repository:
 git clone <repo-url> code-is-cheap
 cd code-is-cheap
 ```
+
+Install the Python dependency required by the skill validator:
+
+```bash
+python3 -m pip install pyyaml
+```
+
+> **Note:** On macOS with Homebrew Python you may need `--break-system-packages`, or use a virtual environment.
 
 Sync skills to any local Codex / Claude skill homes that already exist:
 

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -13,6 +13,6 @@ fi
 for skill_dir in "$repo_root"/skills/*; do
   [[ -d "$skill_dir" ]] || continue
   echo "Validating ${skill_dir#$repo_root/}"
-  python "$validator" "$skill_dir"
+  python3 "$validator" "$skill_dir"
 done
 


### PR DESCRIPTION
## Problem

`./scripts/sync-skills.sh` fails with a `SyntaxError` on macOS because:

1. `validate-skills.sh` invokes bare `python`, which resolves to Python 2.7 (`/Library/Frameworks/Python.framework/Versions/2.7/bin/python`) on macOS. Python 2.7 does not support f-strings used in the validator script.
2. Even after switching to `python3`, the validator fails with `ModuleNotFoundError: No module named 'yaml'` because `pyyaml` is not part of the Python standard library and the README never mentions installing it.

## Fix

- **`scripts/validate-skills.sh`**: Changed `python` → `python3` so it uses the modern interpreter.
- **`README.md` Requirements**: Clarifies the interpreter is invoked as `python3` and lists `pyyaml` as required.
- **`README.md` Install**: Adds the `python3 -m pip install pyyaml` step before the sync command.

## Testing

```
$ ./scripts/sync-skills.sh
Validating skills/deepreview
Skill is valid!
Validating skills/gateflow
Skill is valid!
...
Syncing skills to /Users/.../.codex/skills
Syncing skills to /Users/.../.claude/skills
```