### PR TITLE
[codex] tighten final closeout gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ explicit gates with durable artifacts, review decisions, residual-risk tracking,
 
 This is not a loose collection of prompts. It is a workflow for putting AI coding inside an engineering loop: confirm goals
 and non-goals, plan, review, implement by slices, review code, fix findings, re-review, run aggregate deep review, track
-residual risks, create accepted commits, open a draft PR, run PR review, and continue until `draft-PR-pass`. Merge,
+residual risks, create accepted commits, open a draft PR, run PR review, and continue through final closeout. Merge,
 approval, marking a PR ready for review, requesting reviewers, deleting branches, public comments, and external issue
 changes still require explicit user authorization.
 
@@ -56,7 +56,9 @@ A typical flow is:
 5. After each Agent return, `phaseflow` reads the artifact, adjudicates findings, updates `control_doc`, and advances to the next gate.
 6. After all slices are complete, run aggregate deep review; after fixes and re-review pass, record draft PR readiness and residual-risk ownership.
 7. The draft PR gate pushes, creates a draft PR, runs PR review, fixes accepted findings, re-reviews, creates an accepted PR review commit, and pushes again until `draft-PR-pass`.
-8. After each phase/work unit, `phaseflow` reconciles residual risks, closes resolved risks, marks the current phase complete, and writes the next entry point so the user can merge the PR and continue to the next phase.
+8. Final closeout then records what changed, what was verified, docs updates, finding status, remaining risks and owners, the draft PR URL, and the next entry point.
+9. For issue work units, the draft PR body should link the issue; final closeout should confirm the issue closeout comment and the merge-time closing expectation.
+10. After final closeout passes, the user manually merges the PR, pulls the latest target base branch, clears the agent session if desired, and resumes `phaseflow` from the `control_doc` next entry point.
 
 The point is not to let the agent invent architecture on the fly. The point is to let agents execute reliably inside
 explicit design boundaries and implementation plans, while leaving durable artifacts for every review conclusion, fix
@@ -397,7 +399,7 @@ Standalone Gateflow example:
 ```text
 按照 $gateflow 开发 <work-unit>。
 可选设计依据：docs/host/design.md。
-先做 preflight 和 goal confirmation；用户确认目标、非目标和边界后，按 Gate Order 推进到 draft-PR-pass。
+先做 preflight 和 goal confirmation；用户确认目标、非目标和边界后，按 Gate Order 推进到 final closeout。
 严格遵循 AGENTS.md 的约束。
 ```
 
@@ -424,6 +426,7 @@ Standalone Phaseflow example:
 先读取 control_doc 识别当前 phase/work unit，再读取 design_doc。
 总控 Agent 先完成 preflight 和 goal confirmation；用户确认后，按 Gateflow 的 Gate Order 逐 gate 派发 Agent 完成具体任务。
 每个 gate 返回后更新 control_doc、记录 artifact / finding 裁决 / residual risk。
+final closeout 后说明用户 merge PR、拉取目标 base branch，并从 control_doc 的 next entry point 继续下一轮。
 严格遵循 AGENTS.md 的约束。
 ```
 
@@ -434,6 +437,7 @@ Phaseflow with `init-agents` example:
 $init-agents 路由 Agents，AgentMiMo / AgentDS 负责两路同时 review，AgentCodex 负责 plan / implement / fix。
 总控 Agent 先做 preflight 和 goal confirmation；确认后按 Gateflow 的 Gate Order 逐 gate 派发。
 每个 Agent 返回后，总控读取 artifact、裁决 finding、更新 control_doc、收集 residual risk、关闭已解决 risk。
+final closeout 后说明用户 merge PR、拉取目标 base branch，并从 control_doc 的 next entry point 继续下一轮。
 严格遵循 AGENTS.md 的约束。
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,7 +8,7 @@ residual-risk tracking 和 accepted checkpoint。
 
 它不是一组零散 prompt，而是一套把 AI Coding 纳入工程闭环的工作流：确认目标和非目标，plan、review、按 slice 实施、
 code review、fix、re-review、aggregate deepreview、residual risk tracking、本地 accepted commits、创建 draft PR、执行
-PR review，并持续推进到 `draft-PR-pass`。merge、approve、mark ready for review、request reviewers、delete branch、
+PR review，并持续推进到 final closeout。merge、approve、mark ready for review、request reviewers、delete branch、
 对外 comment、创建/修改外部 issue 仍然需要用户额外授权。
 
 本仓库包含用于 Codex / Claude Code 的本地 skills 和配套脚本，覆盖 phase-driven development、gated feature
@@ -55,7 +55,9 @@ $phaseflow design_doc=docs/host/design.md control_doc=docs/host/issues-implement
 5. 每个 Agent 返回后，`phaseflow` 读取 artifact、裁决 findings、更新 `control_doc`，再进入下一个 gate。
 6. 所有 slices 完成后执行 aggregate deepreview；修复并复核通过后，记录 draft PR readiness 和 residual-risk owner。
 7. draft PR gate 自动 push、创建 draft PR、执行 PR review；若有 accepted findings，则自动 fix、re-review、提交 accepted PR review commit 并再次 push，直到 `draft-PR-pass`。
-8. 每个 phase/work unit 完成后，`phaseflow` reconcile residual risks、关闭已解决风险、标记当前 phase 完成，并写入 next entry point，方便用户 merge PR 后继续下一个 phase。
+8. final closeout 随后记录变更内容、验证结果、文档更新、finding 状态、剩余风险和 owner、draft PR URL，以及 next entry point。
+9. 如果 work unit 是 issue，draft PR body 应关联 issue；final closeout 应确认 issue closeout comment 和 merge 后关闭预期。
+10. final closeout 通过后，用户手工 merge PR，拉取最新目标 base branch，按需 `/clear`，再从 `control_doc` 的 next entry point 恢复 `phaseflow`。
 
 这个流程的目标不是让 Agent 自行发明架构，而是让 Agent 在已经明确的设计边界和总控计划内稳定执行，并把每一步的证据、
 review 结论、修复状态和 residual risks 留在可追踪 artifact 中。
@@ -395,7 +397,7 @@ fixes、aggregate deepreview、accepted commits、draft PR gate 和 final closeo
 ```text
 按照 $gateflow 开发 <work-unit>。
 可选设计依据：docs/host/design.md。
-先做 preflight 和 goal confirmation；用户确认目标、非目标和边界后，按 Gate Order 推进到 draft-PR-pass。
+先做 preflight 和 goal confirmation；用户确认目标、非目标和边界后，按 Gate Order 推进到 final closeout。
 严格遵循 AGENTS.md 的约束。
 ```
 
@@ -421,6 +423,7 @@ $init-agents 路由 Agents，AgentCodex 负责 plan / implement / fix，AgentMiM
 先读取 control_doc 识别当前 phase/work unit，再读取 design_doc。
 总控 Agent 先完成 preflight 和 goal confirmation；用户确认后，按 Gateflow 的 Gate Order 逐 gate 派发 Agent 完成具体任务。
 每个 gate 返回后更新 control_doc、记录 artifact / finding 裁决 / residual risk。
+final closeout 后说明用户 merge PR、拉取目标 base branch，并从 control_doc 的 next entry point 继续下一轮。
 严格遵循 AGENTS.md 的约束。
 ```
 
@@ -431,6 +434,7 @@ Phaseflow + `init-agents` 示例：
 $init-agents 路由 Agents，AgentMiMo / AgentDS 负责两路同时 review，AgentCodex 负责 plan / implement / fix。
 总控 Agent 先做 preflight 和 goal confirmation；确认后按 Gateflow 的 Gate Order 逐 gate 派发。
 每个 Agent 返回后，总控读取 artifact、裁决 finding、更新 control_doc、收集 residual risk、关闭已解决 risk。
+final closeout 后说明用户 merge PR、拉取目标 base branch，并从 control_doc 的 next entry point 继续下一轮。
 严格遵循 AGENTS.md 的约束。
 ```
 

--- a/skills/gateflow/SKILL.md
+++ b/skills/gateflow/SKILL.md
@@ -45,7 +45,7 @@ git status --short
 如果当前 branch 是 `main`、`master`、`develop`、`release/*` 或项目定义的 protected trunk branch，先停下来让用户确认创建
 工作分支。若 branch、dirty changes 或 scope ownership 不清，也先停下来问用户。
 
-## Goal Confirmation
+## Gate: goal confirmation
 
 进入 plan 前必须完成 goal confirmation：
 
@@ -92,6 +92,17 @@ goal confirmation
 
 `plan review` gate 必须使用 `planreview` skill；`code review`、`aggregate deepreview` 和 `PR review` gates 必须使用 `deepreview` skill。
 
+Gate Order entry 与下方 section 的绑定是执行约束。必须按对应的 `## Gate: ...` 或 `## Gate Group: ...` section 执行：
+
+- `goal confirmation` -> `## Gate: goal confirmation`
+- `plan` -> `## Gate: plan`
+- `implementation -> code review -> fix -> re-review -> accepted slice commit` -> `## Gate Group: implementation slice`
+- `plan review`、`code review`、`aggregate deepreview`、`PR review` 及其 `fix` / `re-review` -> `## Gate Group: review / fix / re-review`
+- `ready-to-open-draft-PR -> ... -> draft-PR-pass` -> `## Gate Group: draft PR`
+- `final closeout` -> `## Gate: final closeout`
+
+不得把 `draft-PR-pass` 当作 work unit 完成；必须继续执行 `final closeout` gate。
+
 多 slice 时重复：
 
 ```text
@@ -110,7 +121,7 @@ implementation -> code review -> fix -> re-review -> accepted slice commit
 - validation failure、unclassified residual risk、deferred finding 或 missing artifact 需要用户决策；
 - 需要 merge、approve、mark ready for review、request reviewers、delete branch、对外 comment 或创建/修改外部 issue。
 
-## Plan Gate
+## Gate: plan
 
 plan 必须 code-generation-ready，即可以直接指导实现，不需要重新设计方案、发明契约、猜 file ownership、猜 state transition
 或决定 test scope。
@@ -132,7 +143,7 @@ plan 必须包含：
 
 plan 必须显式说明为什么当前方案没有过度设计。
 
-## Slice Gate
+## Gate Group: implementation slice
 
 每个 slice 必须足够小，适合一次 implementation pass 和一次 review pass。每个 slice 必须写清：
 
@@ -147,7 +158,7 @@ plan 必须显式说明为什么当前方案没有过度设计。
 
 implementation 只能做当前 approved slice，除非 approved plan 明确允许一次做多个 slice。
 
-## Review Gate
+## Gate Group: review / fix / re-review
 
 review / re-review 必须 evidence-based，并产出 durable artifact。finding 必须能被裁决为：
 
@@ -212,7 +223,7 @@ gateflow: accept PR review for <work-unit>
 
 commit 前必须确认 branch 不是 protected trunk，检查 `git status`，只 stage 当前 gate 相关文件，避免 unrelated dirty changes。
 
-## Draft PR Gate
+## Gate Group: draft PR
 
 `ready-to-open-draft-PR` 前确认：
 
@@ -223,6 +234,7 @@ commit 前必须确认 branch 不是 protected trunk，检查 `git status`，只
 - tests/type checks 已运行或失败已说明；
 - docs decision 已完成；
 - deferred findings/residual risks 有 owner/destination；
+- 如果当前 work unit 是 issue，创建 draft PR 时 PR body 必须关联 issue：完整解决时使用 GitHub closing keyword（如 `Closes #123`），部分解决或仅关联时使用非关闭引用（如 `Related to #123`）并说明剩余 owner/destination；
 - draft PR summary 匹配真实代码，不把 future work 写成已完成。
 
 到达 `ready-to-open-draft-PR` 后自动：
@@ -241,9 +253,9 @@ push
 PR review 有 accepted findings 时，必须自动修复并 re-review。PR review 若无 accepted findings，也必须提交 PR review artifact /
 pass evidence 并 push。
 
-## Final Closeout
+## Gate: final closeout
 
-`draft-PR-pass` 后输出 final closeout：
+`draft-PR-pass` 后必须输出 final closeout：
 
 - what changed；
 - what was verified；
@@ -251,4 +263,13 @@ pass evidence 并 push。
 - finding status；
 - remaining risks / owners；
 - draft PR URL；
+- issue link status（如果当前 work unit 是 issue，确认 draft PR body 已用 closing keyword 或非关闭引用关联 issue）；
+- issue closeout comment status（如果当前 work unit 是 issue，给 issue 添加 closeout comment，包含 draft PR URL、finding status、remaining risks / owners 和 merge 后关闭预期）；
 - next entry point。
+
+如果当前 work unit 是 issue，`final closeout` gate 必须确认：
+
+- PR body 已关联 issue；完整解决时使用 closing keyword，部分解决时不得使用会错误关闭 issue 的 closing keyword；
+- issue 已添加 closeout comment，指向 draft PR，并说明 remaining risks / owners 和 merge 后 issue 是否会自动关闭。
+
+若 draft PR 未关联 issue、issue closeout comment 未添加、缺少权限、issue number 不明确，或 closing keyword 会错误关闭未完成 issue，不得输出 final closeout pass，必须停止并询问用户。

--- a/skills/phaseflow/SKILL.md
+++ b/skills/phaseflow/SKILL.md
@@ -153,6 +153,9 @@ goal confirmation
 
 `plan review` gate 必须使用 `planreview` skill；`code review`、`aggregate deepreview` 和 `PR review` gates 必须使用 `deepreview` skill。
 
+`final closeout` gate 在下方 `## Gate: final closeout` 定义。不得把 `draft-PR-pass` 当作 phase/work unit 完成；必须继续执行
+`final closeout` gate。
+
 多 slice 时重复：
 
 ```text
@@ -202,20 +205,52 @@ implementation -> code review -> fix -> re-review -> accepted slice commit
 - 每个 slice commit 后：slice 状态、artifact、review 结论、commit hash、未覆盖项；
 - aggregate deepreview/re-review 通过后：aggregate review artifact、accepted deepreview commit hash；
 - ready-to-open-draft-PR 前：draft PR readiness、剩余风险、owner、后续 phase/work unit destination；
-- draft-PR-pass 后：draft PR URL、PR review artifacts、accepted PR review commit hash、follow-up push 状态、remaining risks /
-  owners、当前 phase/work unit 完成状态、issue 更新/关闭状态（如当前 work unit 是 issue）、next entry point。
+- final closeout gate：按 `## Gate: final closeout` 写入 draft PR、review、commit、risk、issue、completion 和 next entry
+  point 状态。
 
 如果 `control_doc` 没有合适位置记录这些内容，先提出具体写入位置或结构。
 
+## Gate: final closeout
+
+`draft-PR-pass` 后，phaseflow 不得直接结束。必须先执行 `final closeout` gate。
+
+`final closeout` 是总控任务，由 phaseflow 自己完成，不派发给 Agent。缺少必须 artifact、issue 状态需要外部授权，或
+`control_doc` 没有合适位置记录结果时，停止并询问用户。
+
+`final closeout` gate 必须按顺序完成：
+
+1. 重新读取 `control_doc`，确认当前 phase/work unit、当前 gate、draft PR URL、PR review artifacts、accepted PR review
+   commit hash、follow-up push 状态和 next entry point。
+2. 读取 final closeout summary、review artifacts、fix artifacts 和 finding 裁决记录。
+3. 汇总 what changed、what was verified、docs updates、finding status、draft PR URL。
+4. 执行 residual risk reconciliation：收集所有 remaining risks，确认每项都有 owner 和 destination。
+5. 更新 `control_doc`：draft PR URL、PR review artifacts、accepted PR review commit hash、follow-up push 状态、remaining
+   risks / owners、当前 phase/work unit 完成状态、issue 关联/评论/关闭预期（如当前 work unit 是 issue）、next entry point。
+6. 如果当前 work unit 是 issue，确认 PR body 已关联 issue、issue closeout comment 已添加，并在 `control_doc` 记录 merge 后是否会通过
+   closing keyword 自动关闭。只有项目流程明确要求手动关闭且用户授权时，才手动 close issue。
+7. 确认 next entry point 指向用户 merge 当前 PR 后可以直接进入的下一个 phase/work unit。
+8. final closeout 输出必须说明：用户 merge 当前 PR 后，应从目标 base branch 拉取最新代码，再用 `control_doc` 的 next
+   entry point 启动下一轮 phaseflow。
+
+存在以下任一情况时，不得关闭 phase/work unit 或输出 final closeout pass：
+
+- 缺少必须 artifact；
+- accepted finding 没有最终状态；
+- residual risk 没有 owner/destination；
+- `control_doc` 未记录 draft PR / review / commit / risk / issue / completion / next entry point 状态；
+- issue work unit 的 issue 状态未处理，或处理需要用户授权；
+- next entry point 不明确，或没有指向 merge 当前 PR 后可继续进入的下一个 phase/work unit；
+- final closeout 输出未说明 merge 当前 PR 后如何从 base branch 和 `control_doc` next entry point 继续下一轮 phaseflow。
+
 ## Residual Risk Reconciliation
 
-每个 phase/work unit 完成后必须：
+`final closeout` gate 内必须执行 residual risk reconciliation：
 
 - 收集 final closeout、review artifacts、fix artifacts 和裁决记录中的 residual risks；
 - 为仍存在的 residual risk 写入 owner、destination、后续 phase/work unit、issue 或 user decision；
 - 删除已 close 的 residual risk；
 - 对已解决但尚未 close 的 residual risk，关闭或标记已解决；
-- 如果当前 work unit 是 issue，更新对应 issue；若该 issue 已完成，close issue；
+- 如果当前 work unit 是 issue，确认 issue 已关联 draft PR、已有 closeout comment，并记录 merge 后关闭预期；只有项目流程明确要求手动关闭且用户授权时，才手动 close issue；
 - 确认 next entry point 指向用户 merge 当前 PR 后可以直接进入的下一个 phase/work unit。
 
 存在没有 owner/destination 的 residual risk 时，不得关闭 phase/work unit。


### PR DESCRIPTION
## Summary

- Rename Gateflow gate sections to `Gate:` / `Gate Group:` forms and bind Gate Order entries to their execution sections.
- Tighten Gateflow issue handling so draft PR bodies link issues and final closeout adds an issue closeout comment.
- Add a dedicated Phaseflow `Gate: final closeout` that centralizes control_doc updates, residual risk reconciliation, issue status handling, and next-entry instructions.

## Why

The previous Phaseflow closeout behavior was spread across multiple sections, which made it easier for Codex or Claude Code to stop at `draft-PR-pass` or miss control_doc/risk/issue bookkeeping. This makes final closeout a concrete gate with stop conditions.

## Validation

- `git diff --check`
- YAML frontmatter sanity check for `skills/gateflow/SKILL.md` and `skills/phaseflow/SKILL.md`